### PR TITLE
Implemented initial thread burst in stepping thread group

### DIFF
--- a/src/kg/apc/jmeter/threads/SteppingThreadGroup.java
+++ b/src/kg/apc/jmeter/threads/SteppingThreadGroup.java
@@ -28,6 +28,10 @@ public class SteppingThreadGroup
     /**
      *
      */
+    private static final String INC_USER_COUNT_BURST = "Start users count burst";
+    /**
+     *
+     */
     private static final String DEC_USER_PERIOD = "Stop users period";
     /**
      *
@@ -58,29 +62,43 @@ public class SteppingThreadGroup
 
         if(inUserCount == 0) inUserCount = getNumThreads();
         if(outUserCount == 0) outUserCount = getNumThreads();
+        
+        //int inUserCountBurst = Math.min(Math.max(inUserCount, getInUserCountBurstAsInt()), getNumThreads());
+        int inUserCountBurst = Math.min(getInUserCountBurstAsInt(), getNumThreads());
+        if (inUserCountBurst <= 0) {
+            inUserCountBurst = inUserCount;
+        }
+        
+        int rampUpBucket = thread.getThreadNum() < inUserCountBurst ? 0 :
+            1 + (thread.getThreadNum() - inUserCountBurst) / inUserCount;
+        int rampUpBucketThreadCount = thread.getThreadNum() < inUserCountBurst ? inUserCountBurst : inUserCount;
 
         int threadGroupDelay = 1000 * getThreadGroupDelayAsInt();
         long ascentPoint = tgStartTime + threadGroupDelay;
         int inUserPeriod = 1000 * getInUserPeriodAsInt();
-        int additionalRampUp = 1000 * getRampUpAsInt() / inUserCount;
+        int additionalRampUp = 1000 * getRampUpAsInt() / rampUpBucketThreadCount;
         int flightTime = 1000 * getFlightTimeAsInt();
         int outUserPeriod = 1000 * getOutUserPeriodAsInt();
         
         long rampUpDuration = 1000 * getRampUpAsInt();
         long iterationDuration = inUserPeriod + rampUpDuration;
         //number of complete iteration, ie full (in user time + rampup duration) used
-        int iterationCountTotal = (int) Math.ceil((double) getNumThreads() / inUserCount) - 1;
-        int iterationCountBeforeMe = (int) Math.floor((double) thread.getThreadNum() / inUserCount);
+        int iterationCountTotal = getNumThreads() < inUserCountBurst ? 1 :
+            (int) Math.ceil((double) (getNumThreads() - inUserCountBurst) / inUserCount);
 
-        int lastIterationUserCount = getNumThreads() % inUserCount;
+        int lastIterationUserCount = (getNumThreads() - inUserCountBurst) % inUserCount;
         if(lastIterationUserCount == 0) lastIterationUserCount = inUserCount;
-        long descentPoint = ascentPoint + iterationCountTotal * iterationDuration + additionalRampUp * lastIterationUserCount + flightTime;
-
-        long startTime = ascentPoint + iterationCountBeforeMe * iterationDuration + (thread.getThreadNum() % inUserCount) * additionalRampUp;
+        long descentPoint = ascentPoint + iterationCountTotal * iterationDuration + (1000 * getRampUpAsInt() / inUserCount) * lastIterationUserCount + flightTime;
+        
+        long rampUpBucketStartTime = ascentPoint + rampUpBucket * iterationDuration;
+        int rampUpBucketThreadPosition = thread.getThreadNum() < inUserCountBurst ? thread.getThreadNum() :
+            (thread.getThreadNum() - inUserCountBurst) % inUserCount;
+        
+        long startTime = rampUpBucketStartTime + rampUpBucketThreadPosition * additionalRampUp;
         long endTime = descentPoint + outUserPeriod * (int) Math.floor((double) thread.getThreadNum() / outUserCount);
 
-        log.debug(String.format("threadNum=%d, rampUpDuration=%d, iterationDuration=%d, iterationCountTotal=%d, iterationCountBeforeMe=%d, ascentPoint=%d, descentPoint=%d, startTime=%d, endTime=%d",
-                thread.getThreadNum(), rampUpDuration, iterationDuration, iterationCountTotal, iterationCountBeforeMe, ascentPoint, descentPoint, startTime, endTime));
+        log.debug(String.format("threadNum=%d, rampUpBucket=%d, rampUpBucketThreadCount=%d, rampUpBucketStartTime=%d, rampUpBucketThreadPosition=%d, rampUpDuration=%d, iterationDuration=%d, iterationCountTotal=%d, ascentPoint=%d, descentPoint=%d, startTime=%d, endTime=%d",
+               thread.getThreadNum(), rampUpBucket, rampUpBucketThreadCount, rampUpBucketStartTime, rampUpBucketThreadPosition, rampUpDuration, iterationDuration, iterationCountTotal, ascentPoint, descentPoint, startTime, endTime));
 
         thread.setStartTime(startTime);
         thread.setEndTime(endTime);
@@ -121,6 +139,14 @@ public class SteppingThreadGroup
 
     public void setInUserCount(String delay) {
         setProperty(INC_USER_COUNT, delay);
+    }
+    
+    public String getInUserCountBurst() {
+        return getPropertyAsString(INC_USER_COUNT_BURST);
+    }
+    
+    public void setInUserCountBurst(String text) {
+        setProperty(INC_USER_COUNT_BURST, text);
     }
 
     /**
@@ -177,6 +203,10 @@ public class SteppingThreadGroup
 
     public int getInUserCountAsInt() {
         return getPropertyAsInt(INC_USER_COUNT);
+    }
+    
+    public int getInUserCountBurstAsInt() {
+        return getPropertyAsInt(INC_USER_COUNT_BURST);
     }
 
     public int getRampUpAsInt() {

--- a/src/kg/apc/jmeter/threads/SteppingThreadGroupGui.java
+++ b/src/kg/apc/jmeter/threads/SteppingThreadGroupGui.java
@@ -73,6 +73,7 @@ public class SteppingThreadGroupGui
     private GraphPanelChart chart;
     private JTextField initialDelay;
     private JTextField incUserCount;
+    private JTextField incUserCountBurst;
     private JTextField incUserPeriod;
     private JTextField flightTime;
     private JTextField decUserCount;
@@ -125,6 +126,7 @@ public class SteppingThreadGroupGui
         totalThreads.setText("100");
         initialDelay.setText("0");
         incUserCount.setText("10");
+        incUserCountBurst.setText("0");
         incUserPeriod.setText("30");
         flightTime.setText("60");
         decUserCount.setText("5");
@@ -149,8 +151,15 @@ public class SteppingThreadGroupGui
         panel.add(new JLabel("seconds.", JLabel.LEFT));
         panel.add(new JLabel());
         panel.add(new JLabel());
-
+ 
+        panel.add(new JLabel());
         panel.add(new JLabel("Then start", JLabel.RIGHT));
+        incUserCountBurst = new JTextField(5);
+        panel.add(incUserCountBurst);
+        panel.add(new JLabel("threads: ", JLabel.LEFT));
+        panel.add(new JLabel(""));
+
+        panel.add(new JLabel("Next, add", JLabel.RIGHT));
         incUserCount = new JTextField(5);
         panel.add(incUserCount);
         panel.add(new JLabel("threads every", JLabel.CENTER));
@@ -183,6 +192,7 @@ public class SteppingThreadGroupGui
         registerJTextfieldForGraphRefresh(totalThreads);
         registerJTextfieldForGraphRefresh(initialDelay);
         registerJTextfieldForGraphRefresh(incUserCount);
+        registerJTextfieldForGraphRefresh(incUserCountBurst);
         registerJTextfieldForGraphRefresh(incUserPeriod);
         registerJTextfieldForGraphRefresh(flightTime);
         registerJTextfieldForGraphRefresh(decUserCount);
@@ -215,6 +225,7 @@ public class SteppingThreadGroupGui
         tgForPreview.setNumThreads(new CompoundVariable(totalThreads.getText()).execute());
         tgForPreview.setThreadGroupDelay(new CompoundVariable(initialDelay.getText()).execute());
         tgForPreview.setInUserCount(new CompoundVariable(incUserCount.getText()).execute());
+        tgForPreview.setInUserCountBurst(new CompoundVariable(incUserCountBurst.getText()).execute());
         tgForPreview.setInUserPeriod(new CompoundVariable(incUserPeriod.getText()).execute());
         tgForPreview.setOutUserCount(new CompoundVariable(decUserCount.getText()).execute());
         tgForPreview.setOutUserPeriod(new CompoundVariable(decUserPeriod.getText()).execute());
@@ -236,6 +247,7 @@ public class SteppingThreadGroupGui
             tg.setProperty(SteppingThreadGroup.NUM_THREADS, totalThreads.getText());
             tg.setThreadGroupDelay(initialDelay.getText());
             tg.setInUserCount(incUserCount.getText());
+            tg.setInUserCountBurst(incUserCountBurst.getText());
             tg.setInUserPeriod(incUserPeriod.getText());
             tg.setOutUserCount(decUserCount.getText());
             tg.setOutUserPeriod(decUserPeriod.getText());
@@ -254,6 +266,7 @@ public class SteppingThreadGroupGui
         totalThreads.setText(tg.getNumThreadsAsString());
         initialDelay.setText(tg.getThreadGroupDelay());
         incUserCount.setText(tg.getInUserCount());
+        incUserCountBurst.setText(tg.getInUserCountBurst());
         incUserPeriod.setText(tg.getInUserPeriod());
         decUserCount.setText(tg.getOutUserCount());
         decUserPeriod.setText(tg.getOutUserPeriod());

--- a/test/kg/apc/jmeter/threads/SteppingThreadGroupTest.java
+++ b/test/kg/apc/jmeter/threads/SteppingThreadGroupTest.java
@@ -62,31 +62,32 @@ public class SteppingThreadGroupTest {
         hashtree.add(new LoopController());
         JMeterThread thread = new JMeterThread(hashtree, null, null);
         SteppingThreadGroup instance = new SteppingThreadGroup();
-        instance.setNumThreads(10);
+        instance.setNumThreads(15);
         instance.setInUserCount("5");
+        instance.setInUserCountBurst("10");
         instance.setInUserPeriod("30");
         instance.setRampUp("10");
         instance.setThreadGroupDelay("5");
         instance.setFlightTime("60");
 
         long s1 = -1, s2;
-        for (int n = 0; n < 5; n++) {
+        for (int n = 0; n < 10; n++) {
             thread.setThreadNum(n);
             instance.scheduleThread(thread);
             s2 = thread.getStartTime();
             if (s1 >= 0) {
-                assertEquals(2000, s2 - s1);
+                assertEquals(1000, s2 - s1);
             }
             s1 = s2;
         }
 
-        thread.setThreadNum(6);
+        thread.setThreadNum(10);
         instance.scheduleThread(thread);
         s2 = thread.getStartTime();
-        assertEquals(34000, s2 - s1);
+        assertEquals(31000, s2 - s1);
         s1 = s2;
 
-        for (int n = 7; n < 9; n++) {
+        for (int n = 11; n < 15; n++) {
             thread.setThreadNum(n);
             instance.scheduleThread(thread);
             s2 = thread.getStartTime();
@@ -154,6 +155,18 @@ public class SteppingThreadGroupTest {
         String result = instance.getInUserCount();
         assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getInUserCountBurst method, of class SteppingThreadGroup.
+     */
+    @Test
+    public void testGetInUserCountBurst() {
+        System.out.println("getInUserCountBurst");
+        SteppingThreadGroup instance = new SteppingThreadGroup();
+        String expResult = "";
+        String result = instance.getInUserCountBurst();
+        assertEquals(expResult, result);
+    }
 
     /**
      * Test of setInUserCount method, of class SteppingThreadGroup.
@@ -164,6 +177,17 @@ public class SteppingThreadGroupTest {
         String delay = "";
         SteppingThreadGroup instance = new SteppingThreadGroup();
         instance.setInUserCount(delay);
+    }
+    
+    /**
+     * Test of setInUserCountBurst method, of class SteppingThreadGroup.
+     */
+    @Test
+    public void testSetInUserCountBurst() {
+        System.out.println("setInUserCountBurst");
+        String delay = "";
+        SteppingThreadGroup instance = new SteppingThreadGroup();
+        instance.setInUserCountBurst(delay);
     }
 
     /**
@@ -291,6 +315,18 @@ public class SteppingThreadGroupTest {
         SteppingThreadGroup instance = new SteppingThreadGroup();
         int expResult = 0;
         int result = instance.getInUserCountAsInt();
+        assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getInUserCountBurstAsInt method, of class SteppingThreadGroup.
+     */
+    @Test
+    public void testGetInUserCountBurstAsInt() {
+        System.out.println("getInUserCountBurstAsInt");
+        SteppingThreadGroup instance = new SteppingThreadGroup();
+        int expResult = 0;
+        int result = instance.getInUserCountBurstAsInt();
         assertEquals(expResult, result);
     }
 


### PR DESCRIPTION
This allows to quickly reach a target number of threads to
then iterate with finer steps around that number.

The ramp up used for the initial burst is the same as for
the other steps.

The plugin is backward compatible and the initial thread burst
defaults to 0, which replicates the old behavior.
