### PR TITLE
extras/src/kg/apc/jmeter/reporters/AutoStop.java: duplicated the logger ...

### DIFF
--- a/extras/src/kg/apc/jmeter/reporters/AutoStop.java
+++ b/extras/src/kg/apc/jmeter/reporters/AutoStop.java
@@ -66,6 +66,7 @@ public class AutoStop
                     //log.debug((sec - respTimeExceededStart)+" "+getResponseTimeSecsAsInt());
                     if (sec - respTimeExceededStart >= testValueRespTimeSec) {
                         log.info("Average Response Time is more than " + getResponseTime() + " for " + getResponseTimeSecs() + "s. Auto-shutdown test...");
+                        System.out.println("kg.apc.jmeter.reporters.AutoStop - Average Response Time is more than " + getResponseTime() + " for " + getResponseTimeSecs() + "s. Auto-shutdown test...");
                         stopTest();
                     }
                 } else {
@@ -79,6 +80,7 @@ public class AutoStop
                     //log.debug((sec - respTimeExceededStart)+" "+getResponseTimeSecsAsInt());
                     if (sec - respLatencyExceededStart >= testValueRespLatencySec) {
                         log.info("Average Latency Time is more than " + getResponseLatency() + " for " + getResponseLatencySecs() + "s. Auto-shutdown test...");
+                        System.out.println("kg.apc.jmeter.reporters.AutoStop - Average Latency Time is more than " + getResponseLatency() + " for " + getResponseLatencySecs() + "s. Auto-shutdown test...");
                         stopTest();
                     }
                 } else {
@@ -92,6 +94,7 @@ public class AutoStop
                     //log.debug((sec - errRateExceededStart)+" "+getErrorRateSecsAsInt());
                     if (sec - errRateExceededStart >= testValueErrorSec) {
                         log.info("Error rate more than " + getErrorRate() + " for " + getErrorRateSecs() + "s. Auto-shutdown test...");
+                        System.out.println("kg.apc.jmeter.reporters.AutoStop - Error rate more than " + getErrorRate() + " for " + getErrorRateSecs() + "s. Auto-shutdown test...");
                         stopTest();
                     }
                 } else {

--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -6,6 +6,7 @@
   * Fix DbMon Samples Collector use one jdbc connection for the same Pool Name and close connections when test ended
   * Fix unnecessary console error message in CMDTool
   * Disable UDP in PerfMon and enable it only via property setting
+  * AutoStop plugin is now printing the reason it stopped the test to the JMeter log file
 
 == [/downloads/file/JMeterPlugins-1.1.1.zip 1.1.1] <i><font color=gray size="1">July 14, 2013</font></i>==
   * *Project has moved to new homepage, http://jmeter-plugins.org/*


### PR DESCRIPTION
duplicated the logger entries with a System.out.println to print the reason why the AutoStop plugin stopped the test. This forces the plugin to show this msg in the JMeter log.!

site/dat/wiki/Changelog.wiki: added comments to the changelog
