### PR TITLE
Updated to v2.39.0 of Selenium WebDriver libs

### DIFF
--- a/webdriver/pom.xml
+++ b/webdriver/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java-version>1.6</java-version>
         <jmeter.version>2.8</jmeter.version>
-        <selenium.version>2.34.0</selenium.version>
+        <selenium.version>2.39.0</selenium.version>
         <powermock.version>1.5</powermock.version>
         <cobertura-maven.version>2.5.2</cobertura-maven.version>
     </properties>


### PR DESCRIPTION
This should fix the issue with JMeter Plugins not working with the latest Firefox
