### PR TITLE
(feature) add mode to generate graphs for each sampler

### DIFF
--- a/common/src/kg/apc/charting/GraphPanelChart.java
+++ b/common/src/kg/apc/charting/GraphPanelChart.java
@@ -33,7 +33,9 @@ import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -45,11 +47,13 @@ import javax.swing.JTextField;
 import javax.swing.JWindow;
 import javax.swing.border.BevelBorder;
 import javax.swing.filechooser.FileNameExtensionFilter;
+
 import kg.apc.charting.plotters.AbstractRowPlotter;
 import kg.apc.charting.plotters.BarRowPlotter;
 import kg.apc.charting.plotters.CSplineRowPlotter;
 import kg.apc.charting.plotters.LineRowPlotter;
 import kg.apc.jmeter.gui.CustomNumberRenderer;
+
 import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
@@ -1084,6 +1088,25 @@ public class GraphPanelChart
             };
             clipboard.setContents(transferable, GraphPanelChart.this);
         }
+    }
+    
+    
+    public void saveGraphPerRowToPNG(File directory, int w, int h) throws IOException{
+        for(Map.Entry<String, AbstractGraphRow> entry : rows.entrySet()){
+            entry.getValue().setDrawOnChart(false);
+        }
+        
+        for(Map.Entry<String, AbstractGraphRow> entry : rows.entrySet()){
+            
+            AbstractGraphRow row = entry.getValue();
+            String fileName = directory.getAbsolutePath() + File.separator + row.label.replace(' ', '_').replace(':', '_') + ".png";
+            row.setDrawOnChart(true);
+            this.invalidateCache();
+            this.updateUI();
+            saveGraphToPNG(new File(fileName), w, h);
+            row.setDrawOnChart(false);
+        }
+        
     }
 
     public void saveGraphToPNG(File file, int w, int h) throws IOException {

--- a/standard/src/kg/apc/cmdtools/ReporterTool.java
+++ b/standard/src/kg/apc/cmdtools/ReporterTool.java
@@ -37,6 +37,7 @@ public class ReporterTool extends AbstractCMDTool {
                 + "--line-weight <num of pixels> " // set graph row line thikness ||
                 + "--extractor-regexps <regExps list> "
                 + "--success-filter <true/false> "
+                + "--graph-per-row <yes/no>"
                 + "]");
     }
 
@@ -210,6 +211,13 @@ public class ReporterTool extends AbstractCMDTool {
                 }
 
                 worker.setSuccessFilter(getLogicValue((String) args.next()));
+            } else if (nextArg.equalsIgnoreCase("--graph-per-row")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException("Missing graph-per-row flag");
+                }
+
+                worker.setGraphPerRow(getLogicValue((String) args.next()));
             } else {
                 worker.processUnknownOption(nextArg, args);
             }

--- a/standard/src/kg/apc/jmeter/PluginsCMDWorker.java
+++ b/standard/src/kg/apc/jmeter/PluginsCMDWorker.java
@@ -46,6 +46,7 @@ public class PluginsCMDWorker {
     private String excludeLabels = "";
     private int successFilter = -1;
     private int markers = -1;
+    private int graphPerRow = -1;
 
     public PluginsCMDWorker() {
         log.info("Using JMeterPluginsCMD v. " + JMeterPluginsUtils.getVersion());
@@ -230,9 +231,19 @@ public class PluginsCMDWorker {
         if ((exportMode & EXPORT_PNG) == EXPORT_PNG) {
             File pngFile = new File(outputPNG);
             forceDir(pngFile);
-
+            
+            if(graphPerRow >= 0) {
+                if (!pngFile.mkdirs() && !pngFile.exists()) {
+                    throw new RuntimeException("Failed to create directory for " + pngFile.getAbsolutePath());
+                }
+            }
+            
             try {
-                pluginInstance.getGraphPanelChart().saveGraphToPNG(pngFile, graphWidth, graphHeight);
+                GraphPanelChart panel = pluginInstance.getGraphPanelChart();
+                if(graphPerRow >= 0)
+                    panel.saveGraphPerRowToPNG(pngFile, graphWidth, graphHeight);
+                else
+                    panel.saveGraphToPNG(pngFile, graphWidth, graphHeight);
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
@@ -331,6 +342,10 @@ public class PluginsCMDWorker {
 
     public void setPreventOutliers(int logicValue) {
         preventOutliers = logicValue;
+    }
+    
+    public void setGraphPerRow(int value){
+        graphPerRow = value;
     }
 
     public void setRowsLimit(int parseInt) {


### PR DESCRIPTION
This micro-change is written to add ability to generate graph not only for whole jtl, but for each sampler. It's useful if scenario contains more than 5 samplers or you're interesting of particular sampler.