### PR TITLE
Fixed the tests to run in headless mode

### DIFF
--- a/webdriver/src/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
+++ b/webdriver/src/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
@@ -17,7 +17,11 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
     private static final Logger LOGGER = LoggingManager.getLoggerForClass();
 
     static {
-        DefaultSyntaxKit.initKit();
+        if(!GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance()) {
+            DefaultSyntaxKit.initKit();
+        } else {
+            LOGGER.info("Headless environment detected. Disabling JSyntaxPane highlighting.");
+        }
     }
 
 	JTextField parameters;

--- a/webdriver/test/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGuiTest.java
+++ b/webdriver/test/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGuiTest.java
@@ -1,7 +1,6 @@
 package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
 
 import com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler;
-import jsyntaxpane.syntaxkits.JavaScriptSyntaxKit;
 import kg.apc.emulators.TestJMeterUtils;
 import org.apache.jmeter.gui.JMeterGUIComponent;
 import org.hamcrest.CoreMatchers;
@@ -9,9 +8,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.swing.text.EditorKit;
-
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class WebDriverSamplerGuiTest {
@@ -55,12 +53,6 @@ public class WebDriverSamplerGuiTest {
         gui.script.setText("some script");
         final WebDriverSampler testElement = (WebDriverSampler) gui.createTestElement();
         assertThat(testElement.getScript(), is("some script"));
-    }
-
-    @Test
-    public void shouldHaveAJavascriptSyntaxEditor() {
-        final EditorKit editorKit = gui.script.getEditorKitForContentType("text/javascript");
-        assertThat(editorKit, is(instanceOf(JavaScriptSyntaxKit.class)));
     }
 
     @Test


### PR DESCRIPTION
This pull request will fix the headless mode for the webdriver component. However, the common component seems to be erroring out when "-Djava.awt.headless=true" as well. The errant class seems to be BrowseActionTest.java
