### PR TITLE
MergeResultsGui: fix REF_START_TIME value

### DIFF
--- a/extras/src/kg/apc/jmeter/vizualizers/MergeResultsGui.java
+++ b/extras/src/kg/apc/jmeter/vizualizers/MergeResultsGui.java
@@ -116,7 +116,7 @@ public class MergeResultsGui extends AbstractGraphPanelVisualizer implements
     public static final int REGEX_EXCLUDE = 7;
 
     private static final int MAX_FILE_HANDLES = 4;
-    private static final long REF_START_TIME = 946682000;
+    private static final long REF_START_TIME = 946681200000L; // 2000-01-01 00:00:00.000
 
     private static final String ACTION_ADD = "add"; // $NON-NLS-1$
     private static final String ACTION_COPY = "copy"; // $NON-NLS-1$


### PR DESCRIPTION
Hi,

There was a problem with the reference start time for the Merge Results tool.

before fix : 1970-01-11 23:58:02.000
after fix : 2000-01-01 00:00:00.000

Regards,
Félix H.
