### PR TITLE
Apply format to csv file (AggregateReportGui)

### DIFF
--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -17,6 +17,7 @@
   * Add in multiple ColorsDispatcher classes (CycleColors, HueRotatePalette
   and CustomPalette). CycleColors is original implementation from 1.2.1
   * Configurable hostname patterns for perfmon metrics (for cleaner charts)
+  * AggregateReportGui: Apply format to save csv file
 
 == 1.2.1 <i><font color=gray size="1">March 9, 2015</font></i>==
   * add [TestPlanCheckTool] to check JMX file consistency without running it

--- a/standard/src/kg/apc/jmeter/vizualizers/AggregateReportGui.java
+++ b/standard/src/kg/apc/jmeter/vizualizers/AggregateReportGui.java
@@ -258,9 +258,8 @@ public class AggregateReportGui extends AbstractGraphPanelVisualizer {
             FileWriter writer = null;
             try {
                 writer = new FileWriter(file);
-                CSVSaveService.saveCSVStats(StatGraphVisualizer.getAllTableData(statModel, FORMATS),writer,
-                        saveHeaders.isSelected() ? StatGraphVisualizer.getLabels(COLUMNS) : null);
-                CSVSaveService.saveCSVStats(statModel, writer, saveHeaders.isSelected());
+                CSVSaveService.saveCSVStats(SynthesisReportGui.getAllTableData(statModel, FORMATS)
+                		, writer, saveHeaders.isSelected() ? COLUMNS : null);
             } catch (FileNotFoundException e) {
                 log.warn(e.getMessage());
             } catch (IOException e) {

--- a/standard/src/kg/apc/jmeter/vizualizers/AggregateReportGui.java
+++ b/standard/src/kg/apc/jmeter/vizualizers/AggregateReportGui.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.text.Format;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -22,6 +24,7 @@ import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.SamplingStatCalculator;
+import org.apache.jmeter.visualizers.StatGraphVisualizer;
 import org.apache.jmeter.visualizers.StatVisualizer;
 import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
@@ -100,19 +103,35 @@ public class AggregateReportGui extends AbstractGraphPanelVisualizer {
     }
     // Column renderers
     private static final TableCellRenderer[] RENDERERS =
-            new TableCellRenderer[]{
-        null, // Label
-        null, // count
-        null, // Mean
-        null, // median
-        null, // 90%
-        null, // Min
-        null, // Max
-        new NumberRenderer("#0.00%"), // Error %age 
-        new RateRenderer("#.0"), // Throughput 
-        new NumberRenderer("#.0"), // pageSize   
-        new NumberRenderer("#0.00"), // Std Dev.
-    };
+        new TableCellRenderer[]{
+            null, // Label
+            null, // count
+            null, // Mean
+            null, // median
+            null, // 90%
+            null, // Min
+            null, // Max
+            new NumberRenderer("#0.00%"), // Error %age
+            new RateRenderer("#.0"), // Throughput
+            new NumberRenderer("#.0"), // pageSize
+            new NumberRenderer("#0.00"), // Std Dev.
+        };
+
+    // Column formats
+    static final Format[] FORMATS =
+        new Format[]{
+            null, // Label
+            null, // count
+            null, // Mean
+            null, // median
+            null, // 90%
+            null, // Min
+            null, // Max
+            new DecimalFormat("#0.00%"), // Error %age
+            new DecimalFormat("#.0"), // Throughput
+            new DecimalFormat("#.0"), // pageSize
+            new DecimalFormat("#0.00"), // Std Dev.
+        };
 
     @Override
     public String getLabelResource() {
@@ -239,6 +258,8 @@ public class AggregateReportGui extends AbstractGraphPanelVisualizer {
             FileWriter writer = null;
             try {
                 writer = new FileWriter(file);
+                CSVSaveService.saveCSVStats(StatGraphVisualizer.getAllTableData(statModel, FORMATS),writer,
+                        saveHeaders.isSelected() ? StatGraphVisualizer.getLabels(COLUMNS) : null);
                 CSVSaveService.saveCSVStats(statModel, writer, saveHeaders.isSelected());
             } catch (FileNotFoundException e) {
                 log.warn(e.getMessage());


### PR DESCRIPTION
When it generated AggregateReport csv of jtl files on console, header of csv had 'aggregate_report_error%', but error ratio was no percentage value.
I apply format to CSVSaveSErvice, using StatGraphVisualizer same as other saveGraphToCSV function.