### PR TITLE
Ultimate thread group upgrade

### DIFF
--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -18,6 +18,7 @@
   and CustomPalette). CycleColors is original implementation from 1.2.1
   * Configurable hostname patterns for perfmon metrics (for cleaner charts)
   * AggregateReportGui: Apply format to save csv file
+  * UltimateThreadGroup: Added parametrization via _threads_schedule_ property. 
 
 == 1.2.1 <i><font color=gray size="1">March 9, 2015</font></i>==
   * add [TestPlanCheckTool] to check JMX file consistency without running it

--- a/site/dat/wiki/UltimateThreadGroup.wiki
+++ b/site/dat/wiki/UltimateThreadGroup.wiki
@@ -14,3 +14,22 @@ Let's configure Ultimate Thread Group as following:
 And then try to run test. Look how predictable our [ActiveThreadsOverTime active threads] graph is:
 
 [/img/wiki/ultimate_thread_group2.png]
+
+== Special Property Processing ==
+
+There is a way to configure thread group from special jmeter property _threads_schedule_.
+Property can be specified either in user.properties file (jmeter.properties also applicable), or
+from command line like _-J "threads_schedule=..."_. 
+
+Schedule is specified with a list of _spawn_ directives:
+  * _spawn(threadsCount, initalDelay, startupTime, holdLoadFor, shutdownTime)_ - spawns specified threads number and configures start time, ramp-up time, flight time and shutdown time
+  
+Duration values (initialDelay, startupTime, holdLoadFor, shutdownTime) may be specified with shorthand, case-insensitive modifiers:
+  * s - seconds
+  * m - minutes
+  * h - hours
+  * d - days
+
+Duration setting may be combined like _1d11h23m6s_.
+
+Example of load profile string: {{{threads_schedule=spawn(15,1s,1s,1s,1s) spawn(40,1s,3s,1s,2s)}}}

--- a/standard/test/kg/apc/jmeter/threads/UltimateThreadGroupTest.java
+++ b/standard/test/kg/apc/jmeter/threads/UltimateThreadGroupTest.java
@@ -1,12 +1,15 @@
 package kg.apc.jmeter.threads;
 
+import kg.apc.emulators.TestJMeterUtils;
 import kg.apc.jmeter.JMeterPluginsUtils;
+import kg.apc.jmeter.timers.VariableThroughputTimer;
 import org.apache.jmeter.control.LoopController;
 import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
 import org.junit.*;
 
@@ -27,6 +30,7 @@ public class UltimateThreadGroupTest {
      */
     @BeforeClass
     public static void setUpClass() throws Exception {
+        TestJMeterUtils.createJmeterEnv();
     }
 
     /**
@@ -90,6 +94,17 @@ public class UltimateThreadGroupTest {
             thread.setThreadNum(n);
             instance.scheduleThread(thread);
         }
+    }
+
+    @Test
+    public void testSchedule_Prop() {
+        System.out.println("schedule from property");
+        String threadsSchedule = "spawn(1,1s,1s,1s,1m) spawn(2,1s,3s,1s,2h)";
+        JMeterUtils.setProperty(UltimateThreadGroup.DATA_PROPERTY, threadsSchedule);
+        UltimateThreadGroup instance = new UltimateThreadGroup();
+        JMeterUtils.setProperty(UltimateThreadGroup.DATA_PROPERTY, ""); // clear!
+        JMeterProperty result = instance.getData();
+        assertEquals("[[1, 1, 1, 1, 60], [2, 1, 3, 1, 7200]]", result.toString());
     }
 
     /**


### PR DESCRIPTION
Per discussion in this thread: https://groups.google.com/forum/#!topic/jmeter-plugins/1vyLN_wjly8, this code pack contains support for configuring UltimateThreadGroup via external property "threads_schedule" to allow convenient test parametrization. 