### PR TITLE
Fixed permission-denied-error on unix systems in LoadosophiaUploader

### DIFF
--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -3,6 +3,7 @@
 == 1.3.1 <i><font color=gray size="1">planning</font></i>==
   * add connectTime field into Flexible File Writer
   * add [ConnectTimeOverTime Connect Times Over Time] listener to Extras set
+  * fixed permission-denied-error on unix systems in LoadosophiaUploader-reporter when no storeDir is set
 
 == 1.3.0 <i><font color=gray size="1">June 30, 2015</font></i>==
   * Java 7 or higher required

--- a/standard/src/kg/apc/jmeter/reporters/LoadosophiaUploader.java
+++ b/standard/src/kg/apc/jmeter/reporters/LoadosophiaUploader.java
@@ -107,13 +107,13 @@ public class LoadosophiaUploader extends ResultCollector implements StatusNotifi
 
     private void setupSaving() throws IOException {
         String dir = getStoreDir();
-        if (!dir.endsWith(File.separator)) {
-            dir += File.separator;
-        }
-
         File tmpFile;
         try {
-            tmpFile = File.createTempFile("Loadosophia_", ".jtl", new File(dir));
+            File storeDir = null;
+            if (dir != null && !dir.trim().isEmpty()) {
+                storeDir = new File(dir);
+            }
+            tmpFile = File.createTempFile("Loadosophia_", ".jtl", storeDir);
         } catch (IOException ex) {
             informUser("Unable to create temp file: " + ex.getMessage());
             informUser("Try to set another directory in the above field.");

--- a/standard/test/kg/apc/jmeter/reporters/LoadosophiaUploaderTest.java
+++ b/standard/test/kg/apc/jmeter/reporters/LoadosophiaUploaderTest.java
@@ -98,6 +98,46 @@ public class LoadosophiaUploaderTest {
     }
 
     /**
+     * Test of testEnded method, of class LoadosophiaUploader with no storeDir speciefied.
+     * An temporary file in system's temp-folder should be created automatically.
+     */
+    @Test
+    public void testTestEndedWithNoStoreDir() throws IOException {
+        System.out.println("testEnded");
+        JMeterUtils.setProperty("loadosophia.address", "http://localhost/");
+        LinkedList<String[]> response = new LinkedList<String[]>();
+        String[] v1 = {"0", "4"};
+        response.push(v1);
+        String[] v2 = {"0", "4"};
+        response.push(v2);
+        String[] v3 = {"0", "4"};
+        response.push(v3);
+        String[] v4 = {"0", "4"};
+        response.push(v4);
+        LoadosophiaUploader instance = new LoadosophiaUploaderEmul(response);
+        instance.setStoreDir("");
+        instance.setTitle("UnitTest");
+        instance.setColorFlag("gray");
+        instance.setProject("DEFAULT");
+        instance.setUploadToken("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        instance.testStarted();
+
+        SampleResult res = new SampleResult();
+        res.sampleStart();
+        res.sampleEnd();
+        SampleEvent event = new SampleEvent(res, "test");
+        instance.sampleOccurred(event);
+
+        FileSystem.copyFile(instance.getFilename(), instance.getFilename() + ".perfmon1");
+        LoadosophiaUploadingNotifier.getInstance().addFile(instance.getFilename() + ".perfmon1");
+
+        FileSystem.copyFile(instance.getFilename(), instance.getFilename() + ".perfmon2");
+        LoadosophiaUploadingNotifier.getInstance().addFile(instance.getFilename() + ".perfmon2");
+
+        instance.testEnded();
+    }
+
+    /**
      * Test of setFilePrefix method, of class LoadosophiaUploader.
      */
     @Test


### PR DESCRIPTION
When a plugin is used to run on multiple environments, it is sometimes preferable that the storeDir is set to the system's default temp directory. I tried out not to set storeDir at all, but then i got a "premission denied" error because the code tries to set an trailing slash to an empty string resulting in "/" which is then passed to File.createTempFile("Loadosophia_", ".jtl", new File("/")); which results in an temp-file in the root directory. If run with unprivileged user, it will fail to create that file.

Why is it necessary to set storeDir? Why don't you use the system's temp folder in all cases?