### PR TITLE
(feature) Add basic PhantomJS capability to Remote WebDriver

### DIFF
--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -7,6 +7,7 @@
   * fix scheduling bug in TST for sub-rps load
   * fixed permission-denied-error on unix systems in LoadosophiaUploader-reporter when no storeDir is set
   * bump up Selenium dependency to 2.47.0
+  * add basic PhantomJS (GhostDriver) capability to Remote WebDriver
 
 == 1.3.0 <i><font color=gray size="1">June 30, 2015</font></i>==
   * Java 7 or higher required

--- a/site/dat/wiki/Contributors.wiki
+++ b/site/dat/wiki/Contributors.wiki
@@ -18,3 +18,4 @@ Everyone who provided pull request or other contribution, deserves mentioning on
   * Jorge S. Cruz - added [RemoteDriverConfig] for connecting to a Selenium Grid
   * Roy de Kleijn - added NTLM and Internet Explorer support
   * Erik Ostermueller - added support for changing line & legend colors.
+  * Flávio Cysne - added PhantomJS option to [RemoteCapability] enabling connection to a PhantomJS node in a Selenium Grid

--- a/webdriver/pom.xml
+++ b/webdriver/pom.xml
@@ -127,6 +127,28 @@
         </dependency>
         -->
         <!-- end need this libraries for HtmlUnitDriver -->
+        <!-- start needed libraries for GhostDriver -->
+        <dependency>
+        	<groupId>com.github.detro</groupId>
+        	<artifactId>phantomjsdriver</artifactId>
+        	<version>1.2.0</version>
+        	<exclusions>
+        		<exclusion>
+        			<groupId>org.seleniumhq.selenium</groupId>
+        			<artifactId>selenium-java</artifactId>
+        		</exclusion>
+        		<exclusion>
+        			<groupId>org.seleniumhq.selenium</groupId>
+        			<artifactId>selenium-remote-driver</artifactId>
+        		</exclusion>
+        	</exclusions>
+        </dependency>
+        <dependency>
+        	<groupId>cglib</groupId>
+        	<artifactId>cglib-nodep</artifactId>
+        	<version>2.1_3</version>
+        </dependency>
+        <!-- end needed libraries for GhostDriver -->
         <dependency>
             <groupId>de.sciss</groupId>
             <artifactId>jsyntaxpane</artifactId>

--- a/webdriver/pom.xml
+++ b/webdriver/pom.xml
@@ -291,7 +291,8 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeArtifactIds>
                                 selenium-support,selenium-api,selenium-remote-driver,selenium-ie-driver,selenium-firefox-driver,selenium-chrome-driver,selenium-htmlunit-driver,gson,
-                                guava,json,commons-exec,jsyntaxpane,htmlunit,htmlunit-core-js,nekohtml,cssparser,jetty-websocket,sac,httpclient,httpmime,httpcore
+                                guava,json,commons-exec,jsyntaxpane,htmlunit,htmlunit-core-js,nekohtml,cssparser,jetty-websocket,sac,httpclient,httpmime,httpcore,
+                                cglib-nodep,phantomjsdriver
                             </includeArtifactIds>
                         </configuration>
                     </execution>

--- a/webdriver/src/com/googlecode/jmeter/plugins/webdriver/config/RemoteCapability.java
+++ b/webdriver/src/com/googlecode/jmeter/plugins/webdriver/config/RemoteCapability.java
@@ -3,5 +3,6 @@ package com.googlecode.jmeter.plugins.webdriver.config;
 public enum RemoteCapability {
 	CHROME,
 	FIREFOX,
-	INTERNET_EXPLORER
+	INTERNET_EXPLORER,
+	PHANTOMJS
 }

--- a/webdriver/src/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactory.java
+++ b/webdriver/src/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactory.java
@@ -22,6 +22,9 @@ public class RemoteDesiredCapabilitiesFactory {
 	  } else if (RemoteCapability.INTERNET_EXPLORER.equals(capability)){
 		  desiredCapabilities = DesiredCapabilities.internetExplorer();
 		  return desiredCapabilities;
+	  } else if (RemoteCapability.PHANTOMJS.equals(capability)){
+		  desiredCapabilities = DesiredCapabilities.phantomjs();
+		  return desiredCapabilities;
 	  }
 	  throw new IllegalArgumentException("No such capability");
   }

--- a/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
+++ b/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
@@ -10,26 +10,34 @@ import static org.hamcrest.core.Is.*;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 public class RemoteDesiredCapabilitiesFactoryTest {
-	
+
 	@Test
 	public void shouldReturnFirefoxDriverWhenFirefoxCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.FIREFOX);
 		assertThat(capabilities.getCapability(FirefoxDriver.PROFILE), is(notNullValue()));
 		assertThat(capabilities.getBrowserName(), is("firefox"));
 	}
-	
+
 	@Test
 	public void shouldReturnChromeDriverWhenChromeCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.CHROME);
 		assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
 		assertThat(capabilities.getBrowserName(), is("chrome"));
 	}
-	
+
 	@Test
 	public void shouldReturnInternetExplorerDriverWhenChromeCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.INTERNET_EXPLORER);
 		assertThat(capabilities.getBrowserName(), is("internet explorer"));
 	}
+
+	@Test
+	public void shouldReturnPhantomJSDriverWhenChromeCapabilityIsPassed() throws Exception {
+		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.PHANTOMJS);
+		assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
+		assertThat(capabilities.getBrowserName(), is("phantomjs"));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void shouldThrowAnExceptionWhenAnInvalidCapabilityIsPassed() throws Exception {
 		RemoteDesiredCapabilitiesFactory.build(null);

--- a/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
+++ b/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
@@ -34,7 +34,6 @@ public class RemoteDesiredCapabilitiesFactoryTest {
 	@Test
 	public void shouldReturnPhantomJSDriverWhenPhantomJSCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.PHANTOMJS);
-		assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
 		assertThat(capabilities.getBrowserName(), is("phantomjs"));
 	}
 

--- a/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
+++ b/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDesiredCapabilitiesFactoryTest.java
@@ -26,13 +26,13 @@ public class RemoteDesiredCapabilitiesFactoryTest {
 	}
 
 	@Test
-	public void shouldReturnInternetExplorerDriverWhenChromeCapabilityIsPassed() throws Exception {
+	public void shouldReturnInternetExplorerDriverWhenInternetExplorerCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.INTERNET_EXPLORER);
 		assertThat(capabilities.getBrowserName(), is("internet explorer"));
 	}
 
 	@Test
-	public void shouldReturnPhantomJSDriverWhenChromeCapabilityIsPassed() throws Exception {
+	public void shouldReturnPhantomJSDriverWhenPhantomJSCapabilityIsPassed() throws Exception {
 		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(RemoteCapability.PHANTOMJS);
 		assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
 		assertThat(capabilities.getBrowserName(), is("phantomjs"));

--- a/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
+++ b/webdriver/test/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
@@ -60,6 +60,8 @@ public class RemoteDriverConfigTest {
 		assertThat(config.getCapability(), is(RemoteCapability.FIREFOX));
 		config.setCapability(RemoteCapability.INTERNET_EXPLORER);
 		assertThat(config.getCapability(), is(RemoteCapability.INTERNET_EXPLORER));
+		config.setCapability(RemoteCapability.PHANTOMJS);
+		assertThat(config.getCapability(), is(RemoteCapability.PHANTOMJS));
 	}
 
     @Test


### PR DESCRIPTION
Since Selenium 2.33 there's the PhantomJS capability and adding this to JMeter-Plugins will enable it to run Headless Browser Testing using a Selenium Grid.