### PR TITLE
Add command line Filter Results tool launch with CMDRunner tool

### DIFF
--- a/extras/src/org/jmeterplugins/protocol/http/control/HttpSimpleTableControl.java
+++ b/extras/src/org/jmeterplugins/protocol/http/control/HttpSimpleTableControl.java
@@ -102,6 +102,7 @@ public class HttpSimpleTableControl extends AbstractTestElement {
         log.info("Port=" + getPort());
         log.info("Dataset directory=" + getDataDir());
         log.info("Timestamp=" + getTimestamp());
+        log.info("STS Version=" + HttpSimpleTableServer.STS_VERSION);
         server = new HttpSimpleTableServer(getPort(), getTimestamp(),
                 getDataDir());
         server.start();

--- a/extras/src/org/jmeterplugins/protocol/http/control/HttpSimpleTableServer.java
+++ b/extras/src/org/jmeterplugins/protocol/http/control/HttpSimpleTableServer.java
@@ -30,6 +30,7 @@ import java.util.*;
 public class HttpSimpleTableServer extends NanoHTTPD implements Stoppable, KeyWaiter {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
+    public static final String STS_VERSION = "1.1";
     public static final String ROOT = "/sts/";
     public static final String ROOT2 = "/sts";
     public static final String URI_INITFILE = "INITFILE";
@@ -59,8 +60,11 @@ public class HttpSimpleTableServer extends NanoHTTPD implements Stoppable, KeyWa
             + "http://hostname:port/sts/READ?READ_MODE=[<i>FIRST</i>,<i>LAST</i>,<i>RANDOM</i>]&KEEP=[<i>TRUE</i>,<i>FALSE</i>]&FILENAME=file.txt</p>"
             + "<p>Return the number of remaining lines of a linked list:<br />"
             + "http://hostname:port/sts/LENGTH?FILENAME=file.txt</p>"
-            + "<p>Add a line into a file: (POST HTTP protocol)<br />"
-            + "FILENAME=file.txt,LINE=D0001123,ADD_MODE=[<i>FIRST</i>,<i>LAST</i>]</p>"
+            + "<p>Add a line into a file: (GET OR POST HTTP protocol)<br />"
+            + "GET  : http://hostname:port/sts/ADD?FILENAME=file.txt&LINE=D0001123&ADD_MODE=[<i>FIRST</i>,<i>LAST</i>]<br />"
+            + "GET Parameters : FILENAME=file.txt&LINE=D0001123&ADD_MODE=[<i>FIRST</i>,<i>LAST</i>]<br />"
+            + "POST : http://hostname:port/sts/ADD<br />"
+            + "POST Parameters : FILENAME=file.txt,LINE=D0001123,ADD_MODE=[<i>FIRST</i>,<i>LAST</i>]</p>"
             + "<p>Save the specified linked list in a file to the default location:<br />"
             + "http://hostname:port/sts/SAVE?FILENAME=file.txt</p>"
             + "<p>Display the list of loaded files and the number of remaining lines for each linked list:<br />"
@@ -127,7 +131,7 @@ public class HttpSimpleTableServer extends NanoHTTPD implements Stoppable, KeyWa
             msg = read(parms.get(PARM_READ_MODE), parms.get(PARM_KEEP),
                     parms.get(PARM_FILENAME));
         }
-        if (uri.equals(ROOT + URI_ADD) && Method.POST.equals(method)) {
+        if (uri.equals(ROOT + URI_ADD) && (Method.POST.equals(method) || (Method.GET.equals(method)))) {
             msg = add(parms.get(PARM_ADD_MODE), parms.get(PARM_LINE),
                     parms.get(PARM_FILENAME));
         }
@@ -417,6 +421,7 @@ public class HttpSimpleTableServer extends NanoHTTPD implements Stoppable, KeyWa
         log.info("DATASET_DIR : " + dataset);
         log.info("TIMESTAMP : " + timestamp);
         log.info("------------------------------");
+        log.info("STS_VERSION : " + STS_VERSION);
         ServerRunner.executeInstance(serv);
     }
 

--- a/site/dat/wiki/Changelog.wiki
+++ b/site/dat/wiki/Changelog.wiki
@@ -1,6 +1,16 @@
 = Changelog =
 
-== 1.3.1 <i><font color=gray size="1">planning</font></i>==
+== 1.4.0 <i><font color=gray size="1">preparing</font></i>==
+  * BlazeMeter Inc. has contributed XMPP testing plugins
+  * BlazeMeter Inc. has contributed PhantomJS support for WebDriver
+  * Modernize project website, change its look a bit
+  * fix consequences of PR #80 further
+  * make Dummy Sampler compatible with JMeter 2.12 and earlier
+  * add custom functions strReplace and strReplaceRegex (thanks to Dima Lulko for suggesting)
+  * add FilterResultsTool command line tool, filter results by label (regex), offset, success, output file XML or CSV format
+  * change HttpSimpleTableServer command ADD a new line for a file with GET (new) or POST protocols
+
+== 1.3.1 <i><font color=gray size="1">October 12, 2015</font></i>==
   * add connectTime field into Flexible File Writer
   * add [ConnectTimeOverTime Connect Times Over Time] listener to Extras set
   * use JMeter's encoding for converting strings to bytes in FFW
@@ -8,6 +18,8 @@
   * fixed permission-denied-error on unix systems in LoadosophiaUploader-reporter when no storeDir is set
   * bump up Selenium dependency to 2.47.0
   * add basic PhantomJS (GhostDriver) capability to Remote WebDriver
+  * fix UTG broken by PR #80
+  * add Connect Time field to dummy sampler
 
 == 1.3.0 <i><font color=gray size="1">June 30, 2015</font></i>==
   * Java 7 or higher required
@@ -257,9 +269,9 @@
   * *[UltimateThreadGroup Ultimate Thread Group], the real killer*
   * *the most wanted [ResponseTimesOverTime Response Times Over Time] Graph*
   * [ThroughputOverTime Transaction Throughput Over Time] Graph
-  * Auto-update GUI for [SteppingThreadGroup Stepping Thread Group] (thanks to St√©phane Hoblingre for the patch)
-  * Copy to Clipboard on all graphs (thanks to St√©phane Hoblingre for the patch)
-  * Anti-aliasing on all graphs (thanks to St√©phane Hoblingre for the patch)
+  * Auto-update GUI for [SteppingThreadGroup Stepping Thread Group] (thanks to St ©phane Hoblingre for the patch)
+  * Copy to Clipboard on all graphs (thanks to St ©phane Hoblingre for the patch)
+  * Anti-aliasing on all graphs (thanks to St ©phane Hoblingre for the patch)
 
 == [/downloads/file/JMeterPlugins-0.2.0.zip 0.2.0] <i><font color=gray size="1">Apr 9, 2010</font></i>==
   * displayable rows selection in [http://code.google.com/p/jmeter-plugins/w/list?q=label:Graph graph listeners]

--- a/site/dat/wiki/Contributors.wiki
+++ b/site/dat/wiki/Contributors.wiki
@@ -12,7 +12,7 @@ Everyone who provided pull request or other contribution, deserves mentioning on
   * Lars Holmberg - [JMXMon] author
   * Matthew Fremont - improved [VariablesFromCSV] a lot
   * UbikLoadPack Team [http://ubikloadpack.com] - implemented [RedisDataSet] and [GraphsGeneratorListener]
-  * Vincent Daburon and Felix Henry - [HttpSimpleTableServer], [SynthesisReport], [MergeResults], temporal and regex filters
+  * Vincent Daburon and Felix Henry - authors for [HttpSimpleTableServer], [SynthesisReport], [MergeResults], [FilterResultsTool], temporal and regex filters for all graphs
   * Sergey Marakhov and Linh Pham - Android Driver Config
   * Bakir Jusufbegovic and Semir Sabic / AtlantBH - a lot of components
   * Jorge S. Cruz - added [RemoteDriverConfig] for connecting to a Selenium Grid

--- a/site/dat/wiki/FilterResultsTool.wiki
+++ b/site/dat/wiki/FilterResultsTool.wiki
@@ -1,0 +1,35 @@
+<div style="float: right" class="plugins_set standard_set">Available in [StandardSet Standard Set]</div>
+= Filter Results Tool <sup><font color=gray size="1">since 1.2.1</font></sup>=
+
+Often it's necessary to filter the results of a test to obtain a global vision with pages without all the urls that are declared in the html page.
+
+It should also filter queries that are not calls to the application but debug samplers or intermediate calculation samplers as beanshell samplers.
+
+If you want to remove the ramp-up phase, you could use offset filters.
+
+== Usage and Parameters ==
+
+Filter results with multi parameters
+
+Example 1 :
+{{{
+jmeter\lib\ext\FilterResults.bat --output-file filteredout.csv --input-file inputfile.jtl --include-label-regex true --include-labels "P[1-3].*"
+}}}
+
+Example 2 :
+{{{
+jmeter/lib/ext/FilterResults.sh --output-file filteredout.xml --input-file inputfile.csv --include-label-regex true --include-labels "P[1-3].*" --start-offset 2 --end-offset 180 --success-filter true --save-as-xml true
+}}}
+
+Parameters are :
+--input-file <filenameIn> --output-file <filenameFilteredOut>
+[ 
+--success-filter <true/false>   (true : Only success samplers, false : all results by default)
+--include-labels <labels list>
+--exclude-labels <labels list>
+--include-labels-regex <true/false>
+--exclude-label-regex <true/false>
+--start-offset <sec>
+--end-offset <sec>
+--save-as-xml <true/false> (false : CSV format by default) "
+]

--- a/site/dat/wiki/FilterResultsTool.wiki
+++ b/site/dat/wiki/FilterResultsTool.wiki
@@ -1,5 +1,5 @@
 <div style="float: right" class="plugins_set standard_set">Available in [StandardSet Standard Set]</div>
-= Filter Results Tool <sup><font color=gray size="1">since 1.2.1</font></sup>=
+= Filter Results Tool <sup><font color=gray size="1">since 1.4.0</font></sup>=
 
 Often it's necessary to filter the results of a test to obtain a global vision with pages without all the urls that are declared in the html page.
 

--- a/site/dat/wiki/HttpSimpleTableServer.wiki
+++ b/site/dat/wiki/HttpSimpleTableServer.wiki
@@ -194,9 +194,20 @@ login5;password5
 
 === ADD ===
 
-*Add a line into a file: (POST HTTP protocol)*
+*Add a line into a file: (GET OR POST HTTP protocol)*
 
-FILENAME=dossier.csv, LINE=D0001123, ADD_MODE={FIRST, LAST}
+GET Protocol
+{{{
+http://hostname:port/sts/ADD?FILENAME=dossier.csv&LINE=D0001123&ADD_MODE={FIRST, LAST}
+}}}
+GET Parameters : FILENAME=dossier.csv&LINE=D0001123&ADD_MODE={FIRST, LAST}
+
+
+POST Protocol
+{{{
+http://hostname:port/sts/ADD
+}}}
+POST Parameters : FILENAME=dossier.csv, LINE=D0001123, ADD_MODE={FIRST, LAST}
 
 HTML format:
 
@@ -212,6 +223,7 @@ Available options:
   * FILENAME=dossier.csv => if doesn't already exist it creates a LinkList in memory
   * LINE=1234;98763 => the line to add
 
+POST Protocol with parameters
 [/img/wiki/http_sts_add_request.png]
 
 === LENGTH  ===

--- a/site/dat/wiki/StandardSet.wiki
+++ b/site/dat/wiki/StandardSet.wiki
@@ -24,6 +24,7 @@ Basic plugins for everyday needs. Does not require additional libs to run.
   * [InterThreadCommunication Inter-Thread Communication]
   * [Functions Custom JMeter Functions] 
   * [TestPlanCheckTool Command-Line Test Plan Consistency Checking Tool]
+  * [FilterResultsTool Command-Line] filtered results by label (regex), offset, success
 
 == Samplers ==
   * [DummySampler Dummy Sampler] for debugging and programming tests

--- a/standard/FilterResults.bat
+++ b/standard/FilterResults.bat
@@ -1,0 +1,23 @@
+@echo off
+
+rem When you are running FilterResults tool with JMeterPluginsCMD use the following parameters
+rem --input-file <filenameIn> --output-file <filenameFilteredOut>
+rem [ 
+rem --success-filter <true/false>   (true : Only success samplers, false : all results by default)
+rem --include-labels <labels list>
+rem --exclude-labels <labels list>
+rem --include-labels-regex <true/false>
+rem --exclude-label-regex <true/false>
+rem --start-offset <sec>
+rem --end-offset <sec>
+rem --save-as-xml <true/false> (false : CSV format by default) "
+rem ]
+
+rem example 1 :
+rem jmeter\lib\ext\FilterResults.bat --output-file filteredout.csv --input-file inputfile.jtl --include-label-regex true --include-labels "P[1-3].*"
+
+rem example 2 :
+rem jmeter\lib\ext\FilterResults.bat --output-file filteredout.xml --input-file inputfile.csv --include-label-regex true --include-labels "P[1-3].*" --start-offset 2 --end-offset 180 --success-filter true --save-as-xml true
+
+rem May be you need to declare the path to the java binary
+java -jar %0\..\CMDRunner.jar --tool FilterResults %*

--- a/standard/FilterResults.sh
+++ b/standard/FilterResults.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# When you are running FilterResults tool with JMeterPluginsCMD use the following parameters
+# --input-file <filenameIn> --output-file <filenameFilteredOut>
+# [ 
+# --success-filter <true/false>   (true : Only success samplers, false : all results by default)
+# --include-labels <labels list>
+# --exclude-labels <labels list>
+# --include-labels-regex <true/false>
+# --exclude-label-regex <true/false>
+# --start-offset <sec>
+# --end-offset <sec>
+# --save-as-xml <true/false> (false : CSV format by default) "
+# ]
+#
+# example 1 :
+# jmeter/lib/ext/FilterResults.sh --output-file filteredout.csv --input-file inputfile.jtl --include-label-regex true --include-labels "P[1-3].*"
+#
+# example 2 :
+# jmeter/lib/ext/FilterResults.sh --output-file filteredout.xml --input-file inputfile.csv --include-label-regex true --include-labels "P[1-3].*" --start-offset 2 --end-offset 180 --success-filter true --save-as-xml true
+#
+# May be you need to declare the path to the java binary
+java -Djava.awt.headless=true -jar $(dirname $0)/CMDRunner.jar --tool FilterResults "$@"

--- a/standard/src/kg/apc/cmdtools/FilterResultsTool.java
+++ b/standard/src/kg/apc/cmdtools/FilterResultsTool.java
@@ -1,0 +1,198 @@
+package kg.apc.cmdtools;
+
+import java.io.PrintStream;
+import java.util.ListIterator;
+
+import org.apache.jmeter.samplers.SampleSaveConfiguration;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+import org.apache.log.Priority;
+import org.jmeterplugins.tools.FilterResults;
+
+import kg.apc.cmd.UniversalRunner;
+import kg.apc.jmeter.JMeterPluginsUtils;
+import kg.apc.jmeter.vizualizers.CorrectedResultCollector;
+
+public class FilterResultsTool extends AbstractCMDTool {
+
+    private static final Logger log = LoggingManager.getLoggerForClass();
+    
+    private FilterResults filterResults = null;
+
+    public FilterResultsTool() {
+        super();
+        JMeterPluginsUtils.prepareJMeterEnv(UniversalRunner.getJARLocation());
+       filterResults = new  FilterResults();
+
+    }
+
+   @Override
+   protected void showHelp(PrintStream os) {
+       os.println("Options for tool 'FilterResults': --input-file <filenameIn> --output-file <filenameFilteredOut> "
+               + " [ "
+               + "--success-filter <true/false> "
+               + "--include-labels <labels list> "
+               + "--exclude-labels <labels list> "
+               + "--include-labels-regex <true/false> " 
+               + "--exclude-label-regex <true/false> "
+               + "--start-offset <sec> "
+               + "--end-offset <sec> "
+               + "--save-as-xml <true/false> (false : CSV format by default) "
+               + " ]");
+   }
+
+    @Override
+    protected int processParams(ListIterator args)
+            throws UnsupportedOperationException, IllegalArgumentException {
+    	
+    	
+        String outputFile = "out.res";
+        
+        LoggingManager.setPriority(Priority.INFO);
+        // first process params without worker created
+        while (args.hasNext()) {
+            String nextArg = (String) args.next();
+            if (nextArg.equals("--loglevel")) {
+                args.remove();
+                String loglevelStr = (String) args.next();
+                args.remove();
+                LoggingManager.setPriority(loglevelStr);
+            }
+        }
+
+        // rewind it
+        while (args.hasPrevious()) {
+            args.previous();
+        }
+
+        
+        
+        CorrectedResultCollector collector = filterResults.getCollector();
+        SampleSaveConfiguration saveConfig = collector.getSaveConfig();
+        
+        while (args.hasNext()) {
+            String nextArg = (String) args.next();
+            log.debug("Arg: " + nextArg);
+            if (nextArg.equalsIgnoreCase("--input-file")) {
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing input file JTL (or CSV) file name");
+                }
+                collector.setProperty("filename", (String) args.next());
+                log.info("--input-file " + collector.getFilename());
+            } else if (nextArg.equalsIgnoreCase("--output-file")) {
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing Output file name");
+                }
+                // outputfile is a parameter to FilterResults
+                outputFile = (String) args.next();
+                log.info("--output-file " + outputFile);
+            } else if (nextArg.equalsIgnoreCase("--include-labels")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing include labels list");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setIncludeLabels((String) args.next());
+                log.info("--include-labels "
+                        + ((CorrectedResultCollector) collector)
+                                .getList(CorrectedResultCollector.INCLUDE_SAMPLE_LABELS));
+            } else if (nextArg.equalsIgnoreCase("--exclude-labels")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing exclude labels list");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setExcludeLabels((String) args.next());
+                log.info("--exclude-labels "
+                        + ((CorrectedResultCollector) collector)
+                                .getList(CorrectedResultCollector.EXCLUDE_SAMPLE_LABELS));
+            } else if (nextArg.equalsIgnoreCase("--success-filter")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing success filter flag (true/false)");
+                }
+
+                collector.setSuccessOnlyLogging(Boolean.valueOf((String) args
+                        .next()));
+                log.info("--success-filter " + collector.isSuccessOnlyLogging());
+            } else if (nextArg.equalsIgnoreCase("--include-label-regex")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing include label regex flag (true/false)");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setEnabledIncludeRegex(Boolean.valueOf((String) args
+                                .next()));
+                log.info("--include-label-regex "
+                        + ((CorrectedResultCollector) collector)
+                                .getRegexChkboxState(CorrectedResultCollector.INCLUDE_REGEX_CHECKBOX_STATE));
+            } else if (nextArg.equalsIgnoreCase("--exclude-label-regex")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing exclude label regex flag (true/false)");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setEnabledExcludeRegex(Boolean.valueOf((String) args
+                                .next()));
+                log.info("--exclude-label-regex "
+                        + ((CorrectedResultCollector) collector)
+                                .getRegexChkboxState(CorrectedResultCollector.EXCLUDE_REGEX_CHECKBOX_STATE));
+            } else if (nextArg.equalsIgnoreCase("--start-offset")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing start offset flag (sec)");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setStartOffset((String) args.next());
+                log.info("--start-offset "
+                        + ((CorrectedResultCollector) collector)
+                                .getPropertyAsString(CorrectedResultCollector.START_OFFSET));
+            } else if (nextArg.equalsIgnoreCase("--end-offset")) {
+
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing end offset flag (sec)");
+                }
+
+                ((CorrectedResultCollector) collector)
+                        .setEndOffset((String) args.next());
+                log.info("--end-offset "
+                        + ((CorrectedResultCollector) collector)
+                                .getPropertyAsString(CorrectedResultCollector.END_OFFSET));
+            } else if (nextArg.equalsIgnoreCase("--save-as-xml")) {
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException(
+                            "Missing save as xml flag (true/false, true = XML/false = CSV)");
+                }
+
+                saveConfig.setAsXml(Boolean.valueOf((String) args.next()));
+                log.info("--save-as-xml " + saveConfig.saveAsXml());
+            } else {
+                throw new UnsupportedOperationException("Unrecognized option: "
+                        + nextArg);
+            }
+        }
+        collector.setSaveConfig(saveConfig);
+        return doJob(collector, outputFile);
+    }
+
+    private int doJob(CorrectedResultCollector collector, String outputFile) {
+    	
+    	return filterResults.doJob(collector, outputFile);
+        
+        }
+    }
+

--- a/standard/src/kg/apc/jmeter/vizualizers/SynthesisReportGui.java
+++ b/standard/src/kg/apc/jmeter/vizualizers/SynthesisReportGui.java
@@ -56,7 +56,6 @@ import kg.apc.charting.GraphPanelChart;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.graphs.AbstractGraphPanelVisualizer;
 
-import org.apache.commons.lang.math.NumberUtils;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;

--- a/standard/src/org/jmeterplugins/tools/FilterResults.java
+++ b/standard/src/org/jmeterplugins/tools/FilterResults.java
@@ -1,0 +1,113 @@
+package org.jmeterplugins.tools;
+
+import java.awt.BorderLayout;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+import org.jmeterplugins.save.MergeResultsService;
+
+import kg.apc.jmeter.graphs.AbstractGraphPanelVisualizer;
+import kg.apc.jmeter.vizualizers.CorrectedResultCollector;
+import kg.apc.jmeter.vizualizers.JSettingsPanel;
+
+/**
+ *
+ */
+public class FilterResults extends AbstractGraphPanelVisualizer {
+    private static final long serialVersionUID = 6432873068917332588L;
+
+    private static final Logger log = LoggingManager.getLoggerForClass();
+    private Collection<String> emptyCollection = new ArrayList<String>();
+
+    private List<SampleResult> samples = new ArrayList<SampleResult>();
+
+
+    public FilterResults() {
+        super();
+        init();
+    }
+
+    /**
+     * Main visualizer setup.
+     */
+    private void init() {
+        this.setLayout(new BorderLayout());
+
+        // MAIN PANEL
+        JPanel mainPanel = new JPanel();
+        Border margin = new EmptyBorder(10, 10, 5, 10);
+
+        mainPanel.setBorder(margin);
+        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+
+        mainPanel.add(makeTitlePanel());
+    }
+
+    // do not insert this vizualiser in any JMeter menu
+    @Override
+    public Collection<String> getMenuCategories() {
+        return emptyCollection;
+    }
+    
+    
+
+    public void add(SampleResult res) {
+        if (!isSampleIncluded(res)) {
+            return;
+        }
+
+        res.setSaveConfig(collector.getSaveConfig());
+        samples.add(res);
+    }
+
+    public CorrectedResultCollector getCollector() {
+    	return (CorrectedResultCollector) createTestElement();
+    }
+    
+    public int doJob(CorrectedResultCollector collector, String outputFile) {
+        log.info("Setup filtering...");
+        setUpFiltering((CorrectedResultCollector) collector);
+        log.info("Loading file...");
+        collector.loadExistingFile();
+
+        if (!samples.isEmpty()) {
+            log.info("Merging results to " + outputFile);
+            collector.setProperty("filename", outputFile);
+            MergeResultsService mrs = new MergeResultsService();
+            mrs.mergeSamples((CorrectedResultCollector) collector, samples);
+            samples.clear();
+        }
+        return 0;
+    }
+
+    @Override
+    public String getWikiPage() {
+        return "FilterResults";
+    }
+
+    @Override
+    public String getLabelResource() {
+        return this.getClass().getSimpleName(); //$NON-NLS-1$
+    }
+
+    @Override
+    protected JSettingsPanel createSettingsPanel() {
+        return new JSettingsPanel(this, 0);
+    }
+
+    @Override
+    public String getStaticLabel() {
+        return "Nobody never should not see this. No, no, no.";
+    }
+
+
+}

--- a/standard/zip.xml
+++ b/standard/zip.xml
@@ -37,6 +37,7 @@
             <includes>
                 <include>JMeterPluginsCMD.*</include>
                 <include>TestPlanCheck.*</include>
+                <include>FilterResults.*</include>
             </includes>
             <fileMode>0755</fileMode>
             <outputDirectory>lib/ext</outputDirectory>


### PR DESCRIPTION
Hi,
I add  FilterResults Tool launch with the "CMDRunner.jar --tool FilterResults"
Example : 
java  -jar %0\..\CMDRunner.jar --tool FilterResults --output-file filter.xml --input-file gestdoc_300sec.csv --include-label-regex true --include-labels "P[1-3].*" --start-offset 2 --end-offset 180 --success-filter true --save-as-xml true
This new tool need also modifications for the CMDRunner tool.
