### PR TITLE
trying to fix wiki to html translation problem

### DIFF
--- a/site/dat/wiki/SettingsPanel.wiki
+++ b/site/dat/wiki/SettingsPanel.wiki
@@ -192,8 +192,8 @@ render (confusingly) the same color if using "cpu=blue".
 - Label matching happens with case-insensitive java.lang.String#contains().  RegEx is not supported.
 
 ====Other Color Tricks====
-If your labels include the text 01, 02, 03, etc, then these colors:
-[/img/wiki/settings/orangeSpectrum.png]
+|| If your labels include the text 01, 02, 03, etc, then these colors: ||
+|| [/img/wiki/settings/orangeSpectrum.png] ||
 ...can be obtained using this property:
 {{{
 #Shades of Orange


### PR DESCRIPTION
Links to these two PNG files are not getting rendered correctly into html by the wiki engine:

http://jmeter-plugins.org/img/wiki/settings/orangeSpectrum.png
http://jmeter-plugins.org/img/wiki/settings/labelToColorMapping.png

...at the bottom of this page:
http://jmeter-plugins.org/wiki/SettingsPanel/

Thanks,
--Erik