### PR TITLE
JsonPathExtractor:reset the matchNr while the array is empty, otherwi…

### DIFF
--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
@@ -125,6 +125,12 @@ public class JSONPathExtractor extends AbstractTestElement implements PostProces
         } catch (Exception e) {
             log.warn("Extract failed", e);
             vars.put(this.getVar(), getDefaultValue());
+            vars.put(this.getVar() + "_matchNr", "0");
+            int k = 1;
+            while (vars.get(this.getVar() + "_" + k) != null) {
+                vars.remove(this.getVar() + "_" + k);
+                k++;
+            }
         }
     }
 


### PR DESCRIPTION
…se it will reuse the values in the previous loop
