### PR TITLE
Common base class for all monitoring plugins

### DIFF
--- a/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizer.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizer.java
@@ -1,0 +1,233 @@
+package kg.apc.jmeter.graphs;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.text.SimpleDateFormat;
+import javax.swing.*;
+import kg.apc.charting.AbstractGraphRow;
+import kg.apc.jmeter.gui.ButtonPanelAddCopyRemove;
+import kg.apc.jmeter.graphs.AbstractOverTimeVisualizer;
+import kg.apc.jmeter.JMeterPluginsUtils;
+import kg.apc.jmeter.vizualizers.JSettingsPanel;
+import kg.apc.jmeter.vizualizers.MonitoringResultsCollector;
+import kg.apc.jmeter.vizualizers.MonitoringSampleResult;
+import org.apache.jmeter.gui.util.PowerTableModel;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jmeter.testelement.property.NullProperty;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+
+/**
+ * Generic class for plotting monitoring results over time.
+ * 
+ */
+public abstract class AbstractMonitoringVisualizer
+        extends AbstractOverTimeVisualizer {
+
+    private static final Logger log = LoggingManager.getLoggerForClass();
+    protected PowerTableModel tableModel;
+    protected JTable grid;
+    protected JTextArea errorTextArea;
+    protected JScrollPane errorPane;
+	
+    // The following column definitions are to be provided by sub-classes:
+    abstract protected String[] getColumnIdentifiers();
+    abstract protected Class[] getColumnClasses();
+    abstract protected Object[] getDefaultValues();
+    abstract protected int[] getColumnWidths();
+
+    // Sub-classes to construct the actual collector:
+	abstract protected MonitoringResultsCollector createMonitoringResultsCollector();
+    
+    @Override
+    abstract public String getWikiPage();
+
+    @Override
+    abstract public String getStaticLabel();
+
+    public AbstractMonitoringVisualizer() {
+        super();
+        setGranulation(1000);
+        graphPanel.getGraphObject().setYAxisLabel("Monitoring results");
+        graphPanel.getGraphObject().getChartSettings().setExpendRows(true);
+    }
+
+    @Override
+    protected JSettingsPanel createSettingsPanel() {
+        return new JSettingsPanel(this,
+                JSettingsPanel.GRADIENT_OPTION
+                | JSettingsPanel.LIMIT_POINT_OPTION
+                | JSettingsPanel.MAXY_OPTION
+                | JSettingsPanel.RELATIVE_TIME_OPTION
+                | JSettingsPanel.AUTO_EXPAND_OPTION
+                | JSettingsPanel.MARKERS_OPTION_DISABLED);
+    }
+    
+    @Override
+    public String getLabelResource() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    protected JPanel getGraphPanelContainer() {
+        JPanel panel = new JPanel(new BorderLayout());
+        JPanel innerTopPanel = new JPanel(new BorderLayout());
+
+        errorPane = new JScrollPane();
+        errorPane.setMinimumSize(new Dimension(100, 50));
+        errorPane.setPreferredSize(new Dimension(100, 50));
+
+        errorTextArea = new JTextArea();
+        errorTextArea.setForeground(Color.red);
+        errorTextArea.setBackground(new Color(255, 255, 153));
+        errorTextArea.setEditable(false);
+        errorPane.setViewportView(errorTextArea);
+
+        registerPopup();
+
+        innerTopPanel.add(createSamplerPanel(), BorderLayout.NORTH);
+        innerTopPanel.add(errorPane, BorderLayout.SOUTH);
+        innerTopPanel.add(getFilePanel(), BorderLayout.CENTER);
+
+        panel.add(innerTopPanel, BorderLayout.NORTH);
+
+        errorPane.setVisible(false);
+
+        return panel;
+    }
+
+    protected void addErrorMessage(String msg, long time) {
+        errorPane.setVisible(true);
+        SimpleDateFormat formatter = new SimpleDateFormat("HH:mm:ss");
+        String newLine = "";
+        if (errorTextArea.getText().length() != 0) {
+            newLine = "\n";
+        }
+        errorTextArea.setText(errorTextArea.getText() + newLine + formatter.format(time) + " - ERROR: " + msg);
+        errorTextArea.setCaretPosition(errorTextArea.getDocument().getLength());
+        updateGui();
+    }
+
+    public void clearErrorMessage() {
+        errorTextArea.setText("");
+        errorPane.setVisible(false);
+    }
+
+    protected void registerPopup() {
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem hideMessagesMenu = new JMenuItem("Hide Error Panel");
+        hideMessagesMenu.addActionListener(new HideAction());
+        popup.add(hideMessagesMenu);
+        errorTextArea.setComponentPopupMenu(popup);
+    }
+
+    @Override
+    public void clearData() {
+        clearErrorMessage();
+        super.clearData();
+    }
+
+    protected Component createSamplerPanel() {
+        JPanel panel = new JPanel(new BorderLayout(5, 5));
+        panel.setBorder(BorderFactory.createTitledBorder("Monitoring Samplers"));
+        panel.setPreferredSize(new Dimension(150, 150));
+
+        JScrollPane scroll = new JScrollPane(createGrid());
+        scroll.setPreferredSize(scroll.getMinimumSize());
+        panel.add(scroll, BorderLayout.CENTER);
+        panel.add(new ButtonPanelAddCopyRemove(grid, tableModel, getDefaultValues()), BorderLayout.SOUTH);
+
+        grid.getTableHeader().setReorderingAllowed(false);
+
+        return panel;
+    }
+
+    protected JTable createGrid() {
+        grid = new JTable();
+        createTableModel();
+        grid.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        grid.setMinimumSize(new Dimension(200, 100));
+
+        for (int i=0; i < getColumnWidths().length; i++) {
+            grid.getColumnModel().getColumn(i).setPreferredWidth(getColumnWidths()[i]);
+        }
+
+        return grid;
+    }
+
+    protected void createTableModel() {
+        tableModel = new PowerTableModel(getColumnIdentifiers(), getColumnClasses());
+        grid.setModel(tableModel);
+    }
+    
+    @Override
+    public TestElement createTestElement() {
+        TestElement te = createMonitoringResultsCollector();
+        modifyTestElement(te);
+        te.setComment(JMeterPluginsUtils.getWikiLinkText(getWikiPage()));
+        return te;
+    }
+    
+    @Override
+    public void modifyTestElement(TestElement te) {
+        super.modifyTestElement(te);
+        if (grid.isEditing()) {
+            grid.getCellEditor().stopCellEditing();
+        }
+
+        if (te instanceof MonitoringResultsCollector) {
+            MonitoringResultsCollector mrc = (MonitoringResultsCollector) te;
+            CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(tableModel, MonitoringResultsCollector.DATA_PROPERTY);
+            mrc.setData(rows);
+        }
+        super.configureTestElement(te);
+    }
+    
+    @Override
+    public void configure(TestElement te) {
+        super.configure(te);
+        MonitoringResultsCollector mrc = (MonitoringResultsCollector) te;
+        JMeterProperty samplerValues = mrc.getSamplerSettings();
+        if (!(samplerValues instanceof NullProperty)) {
+            JMeterPluginsUtils.collectionPropertyToTableModelRows((CollectionProperty) samplerValues, tableModel, getColumnClasses());
+        } else {
+            log.warn("Received null property instead of collection");
+        }
+    }
+    
+    @Override
+    public void add(SampleResult res) {
+        if (res.isSuccessful()) {
+            if(isSampleIncluded(res)) {
+                super.add(res);
+                addMonitoringRecord(res.getSampleLabel(), normalizeTime(res.getStartTime()), MonitoringSampleResult.getValue(res));
+                updateGui(null);
+            }
+        } else {
+            addErrorMessage(res.getResponseMessage(), res.getStartTime());
+        }
+    }
+    
+    protected void addMonitoringRecord(String rowName, long time, double value) {
+        AbstractGraphRow row = model.get(rowName);
+        if (row == null) {
+            row = getNewRow(model, AbstractGraphRow.ROW_AVERAGES, rowName,
+                    AbstractGraphRow.MARKER_SIZE_NONE, false, false, false, true, true);
+        }
+        row.add(time, value);
+    }
+
+    class HideAction
+            implements ActionListener {
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            errorPane.setVisible(false);
+            updateGui();
+        }
+    }
+}

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
@@ -199,13 +199,17 @@ public class MonitoringResultsCollector
     /**
      * No-op implementation that sub-classes are to refine as required.
      */
-    protected void initiateConnectors() {}
+    protected void initiateConnectors() {
+        // may be refined by sub-classes
+    }
 
     /**
      * No-op implementation that sub-classes are to refine as required.
      */
-    protected void shutdownConnectors() {}
-
+    protected void shutdownConnectors() {
+        // may be refined by sub-classes
+    }
+    
     protected void processConnectors() {
         for (MonitoringSampler sampler : samplers) {
             sampler.generateSamples(this);

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
@@ -1,20 +1,17 @@
 package kg.apc.jmeter.vizualizers;
 
 import java.io.File;
-import java.io.InterruptedIOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
-import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
@@ -34,7 +31,6 @@ public class MonitoringResultsCollector
     private Thread workerThread;
     private volatile boolean stop = false;
     protected List<MonitoringSampler> samplers = new ArrayList<MonitoringSampler>();
-    private static boolean autoGenerateFiles;
     private String autoFileBaseName = null;
     private static int counter = 0;
     private String workerHost = null;
@@ -200,8 +196,14 @@ public class MonitoringResultsCollector
         log.debug("End   testEnded");
     }
 
+    /**
+     * No-op implementation that sub-classes are to refine as required.
+     */
     protected void initiateConnectors() {}
 
+    /**
+     * No-op implementation that sub-classes are to refine as required.
+     */
     protected void shutdownConnectors() {}
 
     protected void processConnectors() {

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
@@ -1,0 +1,245 @@
+package kg.apc.jmeter.vizualizers;
+
+import java.io.File;
+import java.io.InterruptedIOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.samplers.SampleEvent;
+import org.apache.jmeter.samplers.SampleSaveConfiguration;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+
+import kg.apc.jmeter.JMeterPluginsUtils;
+
+public class MonitoringResultsCollector
+        extends CorrectedResultCollector
+        implements Runnable, MonitoringSampleGenerator {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggingManager.getLoggerForClass();
+    public static final String DATA_PROPERTY = "samplers";
+
+    private int interval;
+    private Thread workerThread;
+    private volatile boolean stop = false;
+    protected List<MonitoringSampler> samplers = new ArrayList<MonitoringSampler>();
+    private static boolean autoGenerateFiles;
+    private String autoFileBaseName = null;
+    private static int counter = 0;
+    private String workerHost = null;
+    
+	/**
+	 * Jmeter context used to share with worker thread context
+	 */
+	private JMeterContext ctx;
+
+	protected String getPrefix() { return "BaseMon"; }
+
+    protected String getForceFilePropertyName() { return "forceMonitoringFile"; }
+
+    protected boolean getAutoGenerateFiles() { 
+        return JMeterUtils.getPropDefault(getForceFilePropertyName(), "false").trim().equalsIgnoreCase("true"); 
+    }
+
+    private synchronized String getAutoFileName() {
+        String ret = "";
+        counter++;
+        if (autoFileBaseName == null) {
+            Calendar now = Calendar.getInstance();
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd-HHmmss");
+            autoFileBaseName = getPrefix() + "_" + formatter.format(now.getTime());
+        }
+        ret = ret + autoFileBaseName;
+        if (counter > 1) {
+            ret = ret + "_" + counter;
+        }
+        ret = ret + ".csv";
+
+        return ret;
+    }
+
+    protected int getInterval() {
+        return 1000;
+    }
+
+    public MonitoringResultsCollector() {
+        interval = getInterval();
+    }
+
+    public void setData(CollectionProperty rows) {
+        setProperty(rows);
+    }
+
+    public CollectionProperty getSamplerSettings() {
+        JMeterProperty prop = getProperty(DATA_PROPERTY);
+        if (!(prop instanceof CollectionProperty)) {
+            log.warn("Got unexpected property: " + prop);
+            return new CollectionProperty(); // empty collection instead of NullProperty
+        }
+        CollectionProperty rows = (CollectionProperty) prop;
+        return rows;
+    }
+
+    /**
+     * Update the worker thread jmeter context with the main thread one
+     * @param isInit if true the context a full copy is done, if false only update is done
+     */
+    private void syncContext(boolean isInit)
+    {
+    	// jmeter context synchronisation
+    	JMeterContext current = JMeterContextService.getContext();
+		JMeterContext ctx = this.getThreadContext();
+		
+		if (isInit)
+		{
+			current.setCurrentSampler(ctx.getCurrentSampler());
+			current.setEngine(ctx.getEngine());
+			current.setRestartNextLoop(ctx.isRestartNextLoop());
+			current.setSamplingStarted(ctx.isSamplingStarted());
+			current.setThread(ctx.getThread());
+			current.setThreadGroup(ctx.getThreadGroup());
+			current.setThreadNum(ctx.getThreadNum());
+		}
+		current.setVariables(ctx.getVariables());
+		current.setPreviousResult(ctx.getPreviousResult());
+		//current.getSamplerContext().putAll(ctx.getSamplerContext());
+    }
+
+    @Override
+    public synchronized void run() {
+        try {
+            syncContext(true);
+        
+            while (!stop) {
+                long startTime = System.currentTimeMillis();
+                processConnectors();
+                long elapsedTime = System.currentTimeMillis() - startTime;
+                if (interval > elapsedTime) {
+                    this.wait(interval - elapsedTime);
+                }
+                syncContext(false);
+            }
+        }
+        catch (InterruptedException ex) {
+            log.debug("Monitoring thread was interrupted", ex);
+        }
+        log.debug("exiting run()");
+    }
+
+    //ensure we start only on one host (if multiple slaves)
+    private synchronized boolean isWorkingHost(String host) {
+        if (workerHost == null) {
+            workerHost = host;
+            return true;
+        } else {
+            return host.equals(workerHost);
+        }
+    }
+
+    @Override
+    public void testStarted(String host) {
+
+        if (!isWorkingHost(host)) {
+            return;
+        }
+
+        //ensure the data will be saved
+        if (getProperty(FILENAME) == null || getProperty(FILENAME).getStringValue().trim().length() == 0) {
+            if (getAutoGenerateFiles()) {
+                setupSaving(getAutoFileName());
+            } else {
+                log.info(getPrefix()+" monitoring metrics will not be recorded! Please specify a file name in the gui or run the test with -J"+getForceFilePropertyName()+"=true");
+            }
+        }
+
+        ctx = JMeterContextService.getContext();
+        initiateConnectors();
+
+        stop = false;
+        workerThread = new Thread(this);
+        workerThread.start();
+
+        super.testStarted(host);
+    }
+
+    private void setupSaving(String fileName) {
+        SampleSaveConfiguration config = getSaveConfig();
+        JMeterPluginsUtils.doBestCSVSetup(config);
+        setSaveConfig(config);
+        setFilename(fileName);
+        log.info(getPrefix()+" monitoring metrics will be stored in " + new File(fileName).getAbsolutePath());
+    }
+
+    @Override
+    public void testEnded(String host) {
+        log.debug("Start testEnded");
+        workerHost = null;
+        if (workerThread == null) {
+            log.debug("End   testEnded workerThread == null");
+            return;
+        }
+
+        stop = true;
+        shutdownConnectors();
+
+        //reset autoFileName for next test run
+        autoFileBaseName = null;
+        counter = 0;
+        super.testEnded(host);
+        log.debug("End   testEnded");
+    }
+
+    protected void initiateConnectors() {}
+
+    protected void shutdownConnectors() {}
+
+    protected void processConnectors() {
+        for (MonitoringSampler sampler : samplers) {
+            sampler.generateSamples(this);
+            if (stop) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void sampleOccurred(SampleEvent event) {
+        // just dropping regular test samples
+    	
+    	// update JMeterContext for share with samplers thread in order to provide
+    	// updated variables
+    	this.ctx = JMeterContextService.getContext();
+    }
+
+    protected void monitoringSampleOccurred(SampleEvent event) {
+        super.sampleOccurred(event);
+    }
+
+    @Override
+    public void generateSample(double value, String label) {
+        MonitoringSampleResult res = new MonitoringSampleResult();
+        res.setSampleLabel(label);
+        res.setValue(value);
+        res.setSuccessful(true);
+        SampleEvent e = new SampleEvent(res, getPrefix());
+        monitoringSampleOccurred(e);
+    }
+
+	@Override
+	public JMeterContext getThreadContext() {
+		if (this.ctx != null)
+			return this.ctx;
+		return super.getThreadContext();
+	}
+}

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampleGenerator.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampleGenerator.java
@@ -1,0 +1,5 @@
+package kg.apc.jmeter.vizualizers;
+
+public interface MonitoringSampleGenerator {
+    public void generateSample(double d, String string);
+}

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampleResult.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampleResult.java
@@ -1,0 +1,35 @@
+package kg.apc.jmeter.vizualizers;
+
+import org.apache.jmeter.samplers.SampleResult;
+
+public class MonitoringSampleResult
+        extends SampleResult {
+
+    private final long ts;
+
+    public MonitoringSampleResult() {
+        ts = System.currentTimeMillis();
+    }
+
+    // store as responseMessage, as monitoring query can return any value (bigger than float precision)
+    public void setValue(double value) {
+        setStartTime(ts);
+        setResponseMessage(Double.toString(value));
+    }
+
+    @Override
+    public void setResponseMessage(String msg) {
+        super.setResponseMessage(msg);
+        setStartTime(ts);
+    }
+
+    @Deprecated
+    public double getValue() {
+        return Double.valueOf(getResponseMessage());
+    }
+
+    //needed for CSV reload as object created by JMeter is not MonitoringSampleResult but SampleResult
+    public static double getValue(SampleResult res) {
+        return Double.valueOf(res.getResponseMessage());
+    }
+}

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampler.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringSampler.java
@@ -1,0 +1,5 @@
+package kg.apc.jmeter.vizualizers;
+
+public interface MonitoringSampler {
+    public void generateSamples(MonitoringSampleGenerator collector);
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
@@ -1,0 +1,163 @@
+package kg.apc.jmeter.graphs;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import javax.swing.JPanel;
+import kg.apc.charting.AbstractGraphRow;
+import kg.apc.emulators.TestJMeterUtils;
+import kg.apc.jmeter.vizualizers.JSettingsPanel;
+import kg.apc.jmeter.vizualizers.MonitoringResultsCollector;
+import kg.apc.jmeter.vizualizers.MonitoringSampleResult;
+import org.apache.jmeter.testelement.TestElement;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AbstractMonitoringVisualizerTest {
+
+    public AbstractMonitoringVisualizerTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestJMeterUtils.createJmeterEnv();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    public class AbstractMonitoringVisualizerImpl
+            extends AbstractMonitoringVisualizer {
+        
+        public AbstractMonitoringVisualizerImpl() {
+        }
+        
+        @Override
+        protected String[] getColumnIdentifiers() { return new String[]{ "Label", "URL", "Flag", "Value" }; }
+        @Override
+        protected Class[] getColumnClasses() { return new Class[]{ String.class, String.class, Boolean.class, Integer.class }; }
+        @Override
+        protected Object[] getDefaultValues() { return new Object[]{ "", "", Boolean.FALSE, new Integer(0) }; }
+        @Override
+        protected int[] getColumnWidths() { return new int[]{ 100, 200, 20, 50 }; }
+
+        @Override
+        protected MonitoringResultsCollector createMonitoringResultsCollector() { return new MonitoringResultsCollector();}
+        
+        @Override
+        public String getWikiPage() { return "Test"; }
+
+        @Override
+        public String getStaticLabel() { return "AbstractMonitoringVisualizerImpl"; }
+
+        public ConcurrentSkipListMap<String, AbstractGraphRow> getModel_multi() {
+            return model;
+        }
+
+        public ConcurrentSkipListMap<String, AbstractGraphRow> getModel_aggr() {
+            return modelAggregate;
+        }
+    }
+
+    @Test
+    public void testCreateSettingsPanel() {
+        System.out.println("createSettingsPanel");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        JSettingsPanel result = instance.createSettingsPanel();
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetWikiPage() {
+        System.out.println("getWikiPage");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        String result = instance.getWikiPage();
+        assertTrue(result.length() > 0);
+    }
+
+    @Test
+    public void testGetLabelResource() {
+        System.out.println("getLabelResource");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        String result = instance.getLabelResource();
+        assertTrue(result.length() > 0);
+    }
+
+    @Test
+    public void testGetStaticLabel() {
+        System.out.println("getStaticLabel");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        String result = instance.getStaticLabel();
+        assertTrue(result.length() > 0);
+    }
+
+    @Test
+    public void testCreateTestElement() {
+        System.out.println("createTestElement");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        TestElement result = instance.createTestElement();
+        assertTrue(result instanceof MonitoringResultsCollector);
+    }
+
+    @Test
+    public void testModifyTestElement() {
+        System.out.println("modifyTestElement");
+        TestElement c = new MonitoringResultsCollector();
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        instance.modifyTestElement(c);
+    }
+
+    @Test
+    public void testConfigure() {
+        System.out.println("configure");
+        TestElement el = new MonitoringResultsCollector();
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        instance.configure(el);
+    }
+
+    @Test
+    public void testAdd() {
+        System.out.println("add");
+        MonitoringSampleResult res = new MonitoringSampleResult();
+        res.setSuccessful(true);
+        res.setValue(1.0);
+        AbstractMonitoringVisualizerImpl instance = new AbstractMonitoringVisualizerImpl();
+        instance.add(res);
+        assertEquals(1, instance.getModel_multi().size());
+        assertEquals(1, instance.getModel_multi().firstEntry().getValue().size());
+        assertEquals(0, instance.getModel_aggr().size());
+    }
+
+    @Test
+    public void testGetGraphPanelContainer() {
+        System.out.println("getGraphPanelContainer");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        JPanel result = instance.getGraphPanelContainer();
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testClearErrorMessage() {
+        System.out.println("clearErrorMessage");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        instance.clearErrorMessage();
+    }
+
+    @Test
+    public void testClearData() {
+        System.out.println("clearData");
+        AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
+        instance.clearData();
+    }
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
@@ -17,31 +17,8 @@ import org.junit.Test;
 
 public class AbstractMonitoringVisualizerTest {
 
-    public AbstractMonitoringVisualizerTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        TestJMeterUtils.createJmeterEnv();
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
-
     public class AbstractMonitoringVisualizerImpl
             extends AbstractMonitoringVisualizer {
-        
-        public AbstractMonitoringVisualizerImpl() {
-        }
         
         @Override
         protected String[] getColumnIdentifiers() { return new String[]{ "Label", "URL", "Flag", "Value" }; }

--- a/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
@@ -8,11 +8,7 @@ import kg.apc.jmeter.vizualizers.JSettingsPanel;
 import kg.apc.jmeter.vizualizers.MonitoringResultsCollector;
 import kg.apc.jmeter.vizualizers.MonitoringSampleResult;
 import org.apache.jmeter.testelement.TestElement;
-import org.junit.After;
-import org.junit.AfterClass;
 import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class AbstractMonitoringVisualizerTest {

--- a/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
@@ -7,6 +7,7 @@ import kg.apc.emulators.TestJMeterUtils;
 import kg.apc.jmeter.vizualizers.JSettingsPanel;
 import kg.apc.jmeter.vizualizers.MonitoringResultsCollector;
 import kg.apc.jmeter.vizualizers.MonitoringSampleResult;
+import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.testelement.TestElement;
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -89,6 +90,7 @@ public class AbstractMonitoringVisualizerTest {
         TestElement c = new MonitoringResultsCollector();
         AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
         instance.modifyTestElement(c);
+        assertNotNull(c.getProperty(MonitoringResultsCollector.DATA_PROPERTY));
     }
 
     @Test
@@ -97,6 +99,7 @@ public class AbstractMonitoringVisualizerTest {
         TestElement el = new MonitoringResultsCollector();
         AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
         instance.configure(el);
+        assertNotNull(instance.tableModel);
     }
 
     @Test
@@ -125,6 +128,7 @@ public class AbstractMonitoringVisualizerTest {
         System.out.println("clearErrorMessage");
         AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
         instance.clearErrorMessage();
+        assertEquals(instance.errorTextArea.getText().length(), 0);
     }
 
     @Test
@@ -132,5 +136,6 @@ public class AbstractMonitoringVisualizerTest {
         System.out.println("clearData");
         AbstractMonitoringVisualizer instance = new AbstractMonitoringVisualizerImpl();
         instance.clearData();
+        assertEquals(instance.relativeStartTime, 0);
     }
 }

--- a/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizerTest.java
@@ -3,11 +3,9 @@ package kg.apc.jmeter.graphs;
 import java.util.concurrent.ConcurrentSkipListMap;
 import javax.swing.JPanel;
 import kg.apc.charting.AbstractGraphRow;
-import kg.apc.emulators.TestJMeterUtils;
 import kg.apc.jmeter.vizualizers.JSettingsPanel;
 import kg.apc.jmeter.vizualizers.MonitoringResultsCollector;
 import kg.apc.jmeter.vizualizers.MonitoringSampleResult;
-import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.testelement.TestElement;
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -35,11 +33,11 @@ public class AbstractMonitoringVisualizerTest {
         @Override
         public String getStaticLabel() { return "AbstractMonitoringVisualizerImpl"; }
 
-        public ConcurrentSkipListMap<String, AbstractGraphRow> getModel_multi() {
+        public ConcurrentSkipListMap<String, AbstractGraphRow> getModelMulti() {
             return model;
         }
 
-        public ConcurrentSkipListMap<String, AbstractGraphRow> getModel_aggr() {
+        public ConcurrentSkipListMap<String, AbstractGraphRow> getModelAggr() {
             return modelAggregate;
         }
     }
@@ -110,9 +108,9 @@ public class AbstractMonitoringVisualizerTest {
         res.setValue(1.0);
         AbstractMonitoringVisualizerImpl instance = new AbstractMonitoringVisualizerImpl();
         instance.add(res);
-        assertEquals(1, instance.getModel_multi().size());
-        assertEquals(1, instance.getModel_multi().firstEntry().getValue().size());
-        assertEquals(0, instance.getModel_aggr().size());
+        assertEquals(1, instance.getModelMulti().size());
+        assertEquals(1, instance.getModelMulti().firstEntry().getValue().size());
+        assertEquals(0, instance.getModelAggr().size());
     }
 
     @Test

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
@@ -19,6 +19,8 @@ public class MonitoringResultsCollectorTest {
         CollectionProperty rows = new CollectionProperty();
         MonitoringResultsCollector instance = new MonitoringResultsCollector();
         instance.setData(rows);
+        JMeterProperty result = instance.getProperty(MonitoringResultsCollector.DATA_PROPERTY);
+        assertNotNull(result);
     }
 
     /**
@@ -39,7 +41,10 @@ public class MonitoringResultsCollectorTest {
     public void testRun() {
         System.out.println("run");
         MonitoringResultsCollector instance = new MonitoringResultsCollector();
-        // instance.run(); avoiding infinite loop
+        Thread t = new Thread(instance);
+        t.start(); 
+        assertTrue(t.isAlive());
+        instance.testEnded(); // stop thread
     }
 
     /**

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
@@ -1,17 +1,11 @@
 package kg.apc.jmeter.vizualizers;
 
-import kg.apc.emulators.TestJMeterUtils;
-
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MonitoringResultsCollectorTest {

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
@@ -1,0 +1,148 @@
+package kg.apc.jmeter.vizualizers;
+
+import kg.apc.emulators.TestJMeterUtils;
+
+import org.apache.jmeter.samplers.SampleEvent;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.JMeterProperty;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MonitoringResultsCollectorTest {
+    
+    public MonitoringResultsCollectorTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        TestJMeterUtils.createJmeterEnv();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of setData method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testSetData() {
+        System.out.println("setData");
+        CollectionProperty rows = new CollectionProperty();
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.setData(rows);
+    }
+
+    /**
+     * Test of getSamplerSettings method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testGetSamplerSettings() {
+        System.out.println("getSamplerSettings");
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        JMeterProperty result = instance.getSamplerSettings();
+        assertNotNull(result);
+    }
+
+    /**
+     * Test of run method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testRun() {
+        System.out.println("run");
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        // instance.run(); avoiding infinite loop
+    }
+
+    /**
+     * Test of testStarted method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testTestStarted() {
+        System.out.println("testStarted");
+        String host = "";
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.testStarted(host);
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+
+    /**
+     * Test of testEnded method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testTestEnded() {
+        System.out.println("testEnded");
+        String host = "";
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.testEnded(host);
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+
+    /**
+     * Test of processConnectors method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testProcessConnectors() {
+        System.out.println("processConnectors");
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.processConnectors();
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+
+    /**
+     * Test of sampleOccurred method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testSampleOccurred() {
+        System.out.println("sampleOccurred");
+        SampleEvent event = null;
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.sampleOccurred(event);
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+
+    /**
+     * Test of monitoringSampleOccurred method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testMonitoringSampleOccurred() {
+        System.out.println("monitoringSampleOccurred");
+        SampleEvent event = new SampleEvent(new SampleResult(), "test");
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.monitoringSampleOccurred(event);
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+
+    /**
+     * Test of generateSample method, of class MonitoringResultsCollector.
+     */
+    @Test
+    public void testGenerateSample() {
+        System.out.println("generateSample");
+        double value = 0.0;
+        String label = "";
+        MonitoringResultsCollector instance = new MonitoringResultsCollector();
+        instance.generateSample(value, label);
+        // TODO review the generated test code and remove the default call to fail.
+
+    }
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollectorTest.java
@@ -16,26 +16,6 @@ import org.junit.Test;
 
 public class MonitoringResultsCollectorTest {
     
-    public MonitoringResultsCollectorTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-        TestJMeterUtils.createJmeterEnv();
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
-
     /**
      * Test of setData method, of class MonitoringResultsCollector.
      */

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
@@ -1,42 +1,31 @@
-/*
- * Copyright 2013 undera.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package kg.apc.jmeter.vizualizers;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class MonitoringSampleGeneratorTest {
-    
-    /**
-     * Test of generateSample method, of class MonitoringSampleGenerator.
-     */
+
     @Test
     public void testGenerateSample() {
         System.out.println("generateSample");
         double d = 0.0;
-        String string = "";
+        String string = "Test";
         MonitoringSampleGenerator instance = new MonitoringSampleGeneratorImpl();
         instance.generateSample(d, string);
-        // TODO review the generated test code and remove the default call to fail.
         
+        String result1 = ((MonitoringSampleGeneratorImpl)instance).metric;
+        double result2 = ((MonitoringSampleGeneratorImpl)instance).value;
+        assertEquals(string, result1);
+        assertEquals(d, result2, 0.0);
     }
 
     public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
+        String metric;
+        double value;
 
         public void generateSample(double d, String string) {
-            // No-op implemenation for testing
+            this.metric = string;
+            this.value = d;
         }
     }
 }

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
@@ -20,8 +20,8 @@ public class MonitoringSampleGeneratorTest {
     }
 
     public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
-        String metric;
-        double value;
+        protected String metric;
+        protected double value;
 
         public void generateSample(double d, String string) {
             this.metric = string;

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
@@ -15,8 +15,6 @@
  */
 package kg.apc.jmeter.vizualizers;
 
-import kg.apc.emulators.TestJMeterUtils;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -25,25 +23,6 @@ import org.junit.Test;
 
 public class MonitoringSampleGeneratorTest {
     
-    public MonitoringSampleGeneratorTest() {
-    }
-    
-    @BeforeClass
-    public static void setUpClass() {
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
-    }
-
     /**
      * Test of generateSample method, of class MonitoringSampleGenerator.
      */
@@ -60,6 +39,9 @@ public class MonitoringSampleGeneratorTest {
 
     public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
 
+        /**
+         * No-op implemenation for testing.
+         */
         public void generateSample(double d, String string) {
         }
     }

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 undera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kg.apc.jmeter.vizualizers;
+
+import kg.apc.emulators.TestJMeterUtils;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MonitoringSampleGeneratorTest {
+    
+    public MonitoringSampleGeneratorTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of generateSample method, of class MonitoringSampleGenerator.
+     */
+    @Test
+    public void testGenerateSample() {
+        System.out.println("generateSample");
+        double d = 0.0;
+        String string = "";
+        MonitoringSampleGenerator instance = new MonitoringSampleGeneratorImpl();
+        instance.generateSample(d, string);
+        // TODO review the generated test code and remove the default call to fail.
+        
+    }
+
+    public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
+
+        public void generateSample(double d, String string) {
+        }
+    }
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleGeneratorTest.java
@@ -15,10 +15,6 @@
  */
 package kg.apc.jmeter.vizualizers;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MonitoringSampleGeneratorTest {
@@ -39,10 +35,8 @@ public class MonitoringSampleGeneratorTest {
 
     public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
 
-        /**
-         * No-op implemenation for testing.
-         */
         public void generateSample(double d, String string) {
+            // No-op implemenation for testing
         }
     }
 }

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
@@ -16,10 +16,6 @@
 package kg.apc.jmeter.vizualizers;
 
 import org.apache.jmeter.samplers.SampleResult;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
@@ -29,7 +29,7 @@ public class MonitoringSampleResultTest {
     }
 
     @Test
-    public void testGetValue_0args() {
+    public void testGetValue0args() {
         System.out.println("getValue");
         MonitoringSampleResult instance = new MonitoringSampleResult();
         instance.setResponseMessage("0");
@@ -39,7 +39,7 @@ public class MonitoringSampleResultTest {
     }
 
     @Test
-    public void testGetValue_SampleResult() {
+    public void testGetValueSampleResult() {
         System.out.println("getValue");
         SampleResult res = new SampleResult();
         res.setResponseMessage("0");

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
@@ -24,26 +24,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class MonitoringSampleResultTest {
-    
-    public MonitoringSampleResultTest() {
-    }
-    
-    @BeforeClass
-    public static void setUpClass() {
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
-    }
-
     /**
      * Test of setValue method, of class MonitoringSampleResult.
      */

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2013 undera.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package kg.apc.jmeter.vizualizers;
 
 import org.apache.jmeter.samplers.SampleResult;
@@ -20,35 +5,29 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class MonitoringSampleResultTest {
-    /**
-     * Test of setValue method, of class MonitoringSampleResult.
-     */
+
     @Test
     public void testSetValue() {
         System.out.println("setValue");
         double value = 0.0;
         MonitoringSampleResult instance = new MonitoringSampleResult();
         instance.setValue(value);
-        // TODO review the generated test code and remove the default call to fail.
-        
+        double expResult = value;
+        double result = instance.getValue();
+        assertEquals(expResult, result, 0.0);
     }
 
-    /**
-     * Test of setResponseMessage method, of class MonitoringSampleResult.
-     */
     @Test
     public void testSetResponseMessage() {
         System.out.println("setResponseMessage");
-        String msg = "";
+        String msg = "Test";
         MonitoringSampleResult instance = new MonitoringSampleResult();
         instance.setResponseMessage(msg);
-        // TODO review the generated test code and remove the default call to fail.
-        
+        String expResult = msg;
+        String result = instance.getResponseMessage();
+        assertEquals(expResult, result);
     }
 
-    /**
-     * Test of getValue method, of class MonitoringSampleResult.
-     */
     @Test
     public void testGetValue_0args() {
         System.out.println("getValue");
@@ -57,13 +36,8 @@ public class MonitoringSampleResultTest {
         double expResult = 0.0;
         double result = instance.getValue();
         assertEquals(expResult, result, 0.0);
-        // TODO review the generated test code and remove the default call to fail.
-        
     }
 
-    /**
-     * Test of getValue method, of class MonitoringSampleResult.
-     */
     @Test
     public void testGetValue_SampleResult() {
         System.out.println("getValue");
@@ -72,7 +46,5 @@ public class MonitoringSampleResultTest {
         double expResult = 0.0;
         double result = MonitoringSampleResult.getValue(res);
         assertEquals(expResult, result, 0.0);
-        // TODO review the generated test code and remove the default call to fail.
-        
     }
 }

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSampleResultTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013 undera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kg.apc.jmeter.vizualizers;
+
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MonitoringSampleResultTest {
+    
+    public MonitoringSampleResultTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of setValue method, of class MonitoringSampleResult.
+     */
+    @Test
+    public void testSetValue() {
+        System.out.println("setValue");
+        double value = 0.0;
+        MonitoringSampleResult instance = new MonitoringSampleResult();
+        instance.setValue(value);
+        // TODO review the generated test code and remove the default call to fail.
+        
+    }
+
+    /**
+     * Test of setResponseMessage method, of class MonitoringSampleResult.
+     */
+    @Test
+    public void testSetResponseMessage() {
+        System.out.println("setResponseMessage");
+        String msg = "";
+        MonitoringSampleResult instance = new MonitoringSampleResult();
+        instance.setResponseMessage(msg);
+        // TODO review the generated test code and remove the default call to fail.
+        
+    }
+
+    /**
+     * Test of getValue method, of class MonitoringSampleResult.
+     */
+    @Test
+    public void testGetValue_0args() {
+        System.out.println("getValue");
+        MonitoringSampleResult instance = new MonitoringSampleResult();
+        instance.setResponseMessage("0");
+        double expResult = 0.0;
+        double result = instance.getValue();
+        assertEquals(expResult, result, 0.0);
+        // TODO review the generated test code and remove the default call to fail.
+        
+    }
+
+    /**
+     * Test of getValue method, of class MonitoringSampleResult.
+     */
+    @Test
+    public void testGetValue_SampleResult() {
+        System.out.println("getValue");
+        SampleResult res = new SampleResult();
+        res.setResponseMessage("0");
+        double expResult = 0.0;
+        double result = MonitoringSampleResult.getValue(res);
+        assertEquals(expResult, result, 0.0);
+        // TODO review the generated test code and remove the default call to fail.
+        
+    }
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013 undera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kg.apc.jmeter.vizualizers;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MonitoringSamplerTest {
+    
+    public MonitoringSamplerTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    public class MonitoringSamplerImpl implements MonitoringSampler {
+        
+        private String metric;
+        private double value;
+        
+        public MonitoringSamplerImpl(String metric, double value) {
+            this.metric = metric;
+            this.value = value;
+        }
+        
+        public void generateSamples(MonitoringSampleGenerator collector) {
+            collector.generateSample(value, metric);
+        }
+    }
+    
+    @Test
+    public void testGenerateSamples() {
+        System.out.println("generateSamples");
+        MonitoringSampleGenerator collector = new MonitoringResultsCollector();
+
+        MonitoringSampler instance = new MonitoringSamplerImpl("TestSample", 1.234);
+        instance.generateSamples(collector);
+    }
+}

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
@@ -1,21 +1,7 @@
-/*
- * Copyright 2013 undera.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package kg.apc.jmeter.vizualizers;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class MonitoringSamplerTest {
 
@@ -33,13 +19,29 @@ public class MonitoringSamplerTest {
             collector.generateSample(value, metric);
         }
     }
-    
+
+    public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
+        String metric;
+        double value;
+
+        public void generateSample(double d, String string) {
+            this.metric = string;
+            this.value = d;
+        }
+    }    
     @Test
     public void testGenerateSamples() {
         System.out.println("generateSamples");
-        MonitoringSampleGenerator collector = new MonitoringResultsCollector();
+        MonitoringSampleGenerator collector = new MonitoringSampleGeneratorImpl();
 
-        MonitoringSampler instance = new MonitoringSamplerImpl("TestSample", 1.234);
+        String expResult1 = "TestSample";
+        double expResult2 = 1.234;
+        MonitoringSampler instance = new MonitoringSamplerImpl(expResult1, expResult2);
         instance.generateSamples(collector);
+        
+        String result1 = ((MonitoringSampleGeneratorImpl)collector).metric;
+        double result2 = ((MonitoringSampleGeneratorImpl)collector).value;
+        assertEquals(expResult1, result1);
+        assertEquals(expResult2, result2, 0.0);
     }
 }

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
@@ -22,25 +22,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MonitoringSamplerTest {
-    
-    public MonitoringSamplerTest() {
-    }
-    
-    @BeforeClass
-    public static void setUpClass() {
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
-    }
 
     public class MonitoringSamplerImpl implements MonitoringSampler {
         

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
@@ -15,10 +15,6 @@
  */
 package kg.apc.jmeter.vizualizers;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MonitoringSamplerTest {

--- a/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/vizualizers/MonitoringSamplerTest.java
@@ -21,8 +21,8 @@ public class MonitoringSamplerTest {
     }
 
     public class MonitoringSampleGeneratorImpl implements MonitoringSampleGenerator {
-        String metric;
-        double value;
+        protected String metric;
+        protected double value;
 
         public void generateSample(double d, String string) {
             this.metric = string;

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -168,6 +168,7 @@
         }
       },
       "1.2": {
+        "changes" : "Bug fix release",
         "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-wssecurity-1.2.jar",
         "depends": [
           "jmeter-core"

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -157,7 +157,7 @@
     "markerClass": "nz.co.breakpoint.jmeter.modifiers.SamplerPayloadAccessor",
     "versions": {
       "1.1": {
-        "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-wssecurity-1.1.jar",
+        "downloadUrl": "https://github.com/tilln/jmeter-wssecurity/releases/download/1.1/jmeter-wssecurity-1.1.jar",
         "depends": [
           "jmeter-core"
         ],
@@ -169,7 +169,7 @@
       },
       "1.2": {
         "changes" : "Bug fix release",
-        "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-wssecurity-1.2.jar",
+        "downloadUrl": "https://github.com/tilln/jmeter-wssecurity/releases/download/1.2/jmeter-wssecurity-1.2.jar",
         "depends": [
           "jmeter-core"
         ],

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -166,6 +166,17 @@
            "wss4j-ws-security-common": "http://central.maven.org/maven2/org/apache/wss4j/wss4j-ws-security-common/2.1.8/wss4j-ws-security-common-2.1.8.jar",
            "xmlsec": "http://central.maven.org/maven2/org/apache/santuario/xmlsec/2.0.8/xmlsec-2.0.8.jar"
         }
+      },
+      "1.2": {
+        "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-wssecurity-1.2.jar",
+        "depends": [
+          "jmeter-core"
+        ],
+        "libs": {
+           "wss4j-ws-security-dom": "http://central.maven.org/maven2/org/apache/wss4j/wss4j-ws-security-dom/2.1.8/wss4j-ws-security-dom-2.1.8.jar",
+           "wss4j-ws-security-common": "http://central.maven.org/maven2/org/apache/wss4j/wss4j-ws-security-common/2.1.8/wss4j-ws-security-common-2.1.8.jar",
+           "xmlsec": "http://central.maven.org/maven2/org/apache/santuario/xmlsec/2.0.8/xmlsec-2.0.8.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
Several existing plugins such as JMXMon, DbMon, Perfmon use a common pattern for building the GUI as well as using a Collector class with a worker thread for collecting the monitoring samples (which use the Response Message field for the queried value).
This pattern should be generalized so that the above as well as future monitoring plugins can inherit the common behavior.
This pull request just adds those common classes (without refactoring existing plugins) for review by maintainers/contributors.
