### PR TITLE
Make GUI help link URL creation conditional

### DIFF
--- a/infra/common/src/main/java/kg/apc/jmeter/JMeterPluginsUtils.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/JMeterPluginsUtils.java
@@ -179,8 +179,12 @@ public abstract class JMeterPluginsUtils {
             return panel;
         }
 
-        if (helpPage.endsWith("Gui")) {
-            helpPage = helpPage.substring(0, helpPage.length() - 3);
+        // build link to help page unless it's already a URL:
+        if (!helpPage.toLowerCase().startsWith("http")) {
+            if (helpPage.endsWith("Gui")) {
+                helpPage = helpPage.substring(0, helpPage.length() - 3);
+            }
+            helpPage = WIKI_BASE + helpPage + "/?utm_source=jmeter&utm_medium=helplink&utm_campaign=" + helpPage;
         }
 
         JLabel icon = new JLabel();
@@ -190,7 +194,7 @@ public abstract class JMeterPluginsUtils {
         link.setForeground(Color.blue);
         link.setFont(link.getFont().deriveFont(Font.PLAIN));
         link.setCursor(new Cursor(Cursor.HAND_CURSOR));
-        link.addMouseListener(new URIOpener(WIKI_BASE + helpPage + "/?utm_source=jmeter&utm_medium=helplink&utm_campaign=" + helpPage));
+        link.addMouseListener(new URIOpener(helpPage));
         Border border = BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.blue);
         link.setBorder(border);
 

--- a/infra/common/src/test/java/kg/apc/jmeter/JMeterPluginsUtilsTest.java
+++ b/infra/common/src/test/java/kg/apc/jmeter/JMeterPluginsUtilsTest.java
@@ -62,6 +62,23 @@ public class JMeterPluginsUtilsTest {
     }
 
     @Test
+    public void testBuildHelpPageUrlInternal() {
+        System.out.println("buildHelpPageUrlInternal");
+        String pageName = "TestWikiPageName";
+        String helpPage = JMeterPluginsUtils.buildHelpPageUrl(pageName);
+        assertTrue(helpPage.startsWith(JMeterPluginsUtils.WIKI_BASE));
+        assertTrue(helpPage.contains(pageName));
+    }
+
+    @Test
+    public void testBuildHelpPageUrlExternal() {
+        System.out.println("buildHelpPageUrlExternal");
+        String externalUrl = "HTTPS://somewhere-else.org/";
+        String helpPage = JMeterPluginsUtils.buildHelpPageUrl(externalUrl);
+        assertEquals(externalUrl, helpPage);
+    }
+
+    @Test
     public void testAddHelpLinkToPanel() {
         System.out.println("addHelpLinkToPanel");
         VerticalPanel titlePanel = new VerticalPanel();


### PR DESCRIPTION
Most plugins have a help link on their title panel which is added via `JMeterPluginsUtils.addHelpLinkToPanel`.
However, this assumes that the help page is hosted on JMeter-Plugins.org and the URL is generated to point there, which does not work for external plugins.
In order for external plugins to still use the help link feature when subclassing common GUI classes (e.g. AbstractGraphPanelVisualizer etc) the help link should not be modified if it already is an (external) URL.