### PR TITLE
Added plugin 'ElasticSearch Backend Listener'

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -390,5 +390,18 @@
         }
       }
     }
+  },
+  {
+    "id": "elasticsearch-backend-listener",
+    "name": "ElasticSearch backend listener",
+    "description": "Apache JMeter plugin for sending sample results to an ElasticSearch engine. <ul><li>Simply add a \"Backend Listener\" and change the implementation</li><li>Change the listener's configuration</li></ul>",
+    "helpUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener",
+    "vendor": "Created by Korteke's modified by Delirius325",
+    "markerClass": "net.kvak.jmeter.backendlistener.elasticsearch.ElasticsearchBackend",
+    "versions": {
+      "1.0": {
+        "downloadUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener/releases/download/1.0/jmeter.backendlistener.elasticsearch.jar"
+      }
+    }
   }
 ]


### PR DESCRIPTION
_Not sure where or how I could add the plugin to the "Plugins manager", but I did find that ".json" file while scanning through the project._ 

The purpose of this plugin is to send sample results to an ElasticSearch engine to be able to monitor results through Kibana (or any other data visualizer that supports ElasticSearch). 

It also has support for build numbers if the tests are launched from Jenkins (only have to add a property "BuildNumber" with the %BUILDNUMBER%/$BUILDNUMBER variable).  This solution helps monitor response time over different builds.