### PR TITLE
ElasticSearch Backend Listener - Updated JAR Name

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -331,7 +331,7 @@
     "markerClass": "net.kvak.jmeter.backendlistener.elasticsearch.ElasticsearchBackend",
     "versions": {
       "1.0": {
-        "downloadUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener/releases/download/1.0/jmeter.backendlistener.elasticsearch.jar"
+        "downloadUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener/releases/download/1.0/elasticsearch-backend-listener-1.0.jar"
       }
     }
   }


### PR DESCRIPTION
Updated the JAR name of the "ElasticSearch Backend Listener" to resolve issue showing the plugin in "Has upgrades".