### PR TITLE
Change logging level when applying default JSON Path Extractor value

### DIFF
--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
@@ -130,7 +130,7 @@ public class JSONPathExtractor extends AbstractTestElement implements PostProces
                 vars.put(this.getVar(), objectToString(jsonPathResult));
             }
         } catch (Exception e) {
-            log.warn("Extract failed", e);
+            log.debug("Extract failed", e);
             vars.put(this.getVar(), getDefaultValue());
             vars.put(this.getVar() + "_matchNr", "0");
             int k = 1;


### PR DESCRIPTION
This is to prevent spamming the log with warnings when the extraction fails and the default value is applied