### PR TITLE
Version 1.5.2 ElasticSearch Backend Listener

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -361,6 +361,10 @@
       "1.5.1": {
         "changes": "Hotfix OkHttp3",
         "downloadUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener/releases/download/1.5.1/elasticsearch-backend-listener-1.5.jar"
+      },
+      "1.5.2": {
+        "changes": "Fixed a bug where long test runs would trigger a crash caused by the connection pool of the OkHttp client",
+        "downloadUrl": "https://github.com/delirius325/JMeter_ElasticsearchBackendListener/releases/download/1.5.2/elasticsearch-backend-listener-1.5.2.jar"
       }
     }
   }


### PR DESCRIPTION
Fixed a bug where long test runs would trigger a crash caused by the connection pool of the OkHttp client