### PR TITLE
Fix bug ReferenceError when using Groovy and use JSyntaxtTextArea ins…

### DIFF
--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
+
+import java.awt.Font;
+import java.awt.HeadlessException;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.fife.ui.rsyntaxtextarea.Theme;
+import org.fife.ui.rtextarea.RUndoManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to handle RSyntaxTextArea code
+ * It's not currently possible to instantiate the RSyntaxTextArea class when running headless.
+ * So we use getInstance methods to create the class and allow for headless testing.
+ */
+class JSyntaxTextArea extends RSyntaxTextArea {
+
+    private static final long serialVersionUID = 211L;
+    private static final Logger log              = LoggerFactory.getLogger(JSyntaxTextArea.class);
+
+    private static final Theme DARCULA_THEME = initTheme(); 
+
+    private final Properties languageProperties = JMeterUtils.loadProperties("org/apache/jmeter/gui/util/textarea.properties"); //$NON-NLS-1$
+
+    private final boolean disableUndo;
+    private static final boolean WRAP_STYLE_WORD = JMeterUtils.getPropDefault("jsyntaxtextarea.wrapstyleword", true);
+    private static final boolean LINE_WRAP       = JMeterUtils.getPropDefault("jsyntaxtextarea.linewrap", true);
+    private static final boolean CODE_FOLDING    = JMeterUtils.getPropDefault("jsyntaxtextarea.codefolding", true);
+    private static final int MAX_UNDOS           = JMeterUtils.getPropDefault("jsyntaxtextarea.maxundos", 50);
+    private static final String USER_FONT_FAMILY = JMeterUtils.getPropDefault("jsyntaxtextarea.font.family", null);
+    private static final int USER_FONT_SIZE      = JMeterUtils.getPropDefault("jsyntaxtextarea.font.size", -1);
+
+    /**
+     * Creates the default syntax highlighting text area. The following are set:
+     * <ul>
+     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
+     * <li>setCodeFoldingEnabled(true)</li>
+     * <li>setAntiAliasingEnabled(true)</li>
+     * <li>setLineWrap(true)</li>
+     * <li>setWrapStyleWord(true)</li>
+     * </ul>
+     * 
+     * @param rows
+     *            The number of rows for the text area
+     * @param cols
+     *            The number of columns for the text area
+     * @param disableUndo
+     *            true to disable undo manager
+     * @return {@link JSyntaxTextArea}
+     */
+    public static JSyntaxTextArea getInstance(int rows, int cols, boolean disableUndo) {
+        try {
+            JSyntaxTextArea jSyntaxTextArea = new JSyntaxTextArea(rows, cols, disableUndo);
+            return jSyntaxTextArea;
+        } catch (HeadlessException e) {
+            // Allow override for unit testing only
+            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
+                return new JSyntaxTextArea(disableUndo) {
+                    private static final long serialVersionUID = 1L;
+                    private String text;
+                    @Override
+                    protected void init() {
+                        try {
+                            super.init();
+                        } catch (HeadlessException|NullPointerException e) {
+                            // ignored
+                        }
+                    }
+                    // Override methods that would fail
+                    @Override
+                    public void setCodeFoldingEnabled(boolean b) {  }
+                    @Override
+                    public void setCaretPosition(int b) { }
+                    @Override
+                    public void discardAllEdits() { }
+                    @Override
+                    public void setText(String t) {
+                        this.text = t;
+                    }
+                    @Override
+                    public String getText() {
+                        return text;
+                    }
+                    @Override
+                    public boolean isCodeFoldingEnabled(){ return true; }
+                };
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Creates the default syntax highlighting text area. The following are set:
+     * <ul>
+     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
+     * <li>setCodeFoldingEnabled(true)</li>
+     * <li>setAntiAliasingEnabled(true)</li>
+     * <li>setLineWrap(true)</li>
+     * <li>setWrapStyleWord(true)</li>
+     * </ul>
+     * 
+     * @param rows
+     *            The number of rows for the text area
+     * @param cols
+     *            The number of columns for the text area
+     * @return {@link JSyntaxTextArea}
+     */
+    public static JSyntaxTextArea getInstance(int rows, int cols) {
+        return getInstance(rows, cols, false);
+    }
+
+    @Deprecated
+    public JSyntaxTextArea() {
+        // For use by test code only
+        this(30, 50, false);
+    }
+
+    // for use by headless tests only
+    private JSyntaxTextArea(boolean dummy) {
+        disableUndo = dummy;
+    }
+
+    /**
+     * Creates the default syntax highlighting text area. The following are set:
+     * <ul>
+     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
+     * <li>setCodeFoldingEnabled(true)</li>
+     * <li>setAntiAliasingEnabled(true)</li>
+     * <li>setLineWrap(true)</li>
+     * <li>setWrapStyleWord(true)</li>
+     * </ul>
+     * 
+     * @param rows
+     *            The number of rows for the text area
+     * @param cols
+     *            The number of columns for the text area
+     * @deprecated use {@link #getInstance(int, int)} instead
+     */
+    @Deprecated
+    public JSyntaxTextArea(int rows, int cols) {
+        this(rows, cols, false);
+    }
+
+    /**
+     * Creates the default syntax highlighting text area. The following are set:
+     * <ul>
+     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
+     * <li>setCodeFoldingEnabled(true)</li>
+     * <li>setAntiAliasingEnabled(true)</li>
+     * <li>setLineWrap(true)</li>
+     * <li>setWrapStyleWord(true)</li>
+     * </ul>
+     * 
+     * @param rows
+     *            The number of rows for the text area
+     * @param cols
+     *            The number of columns for the text area
+     * @param disableUndo
+     *            true to disable undo manager, defaults to false
+     * @deprecated use {@link #getInstance(int, int, boolean)} instead
+     */
+    @Deprecated
+    public JSyntaxTextArea(int rows, int cols, boolean disableUndo) {
+        super(rows, cols);
+        super.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA);
+        super.setCodeFoldingEnabled(CODE_FOLDING);
+        super.setAntiAliasingEnabled(true);
+        super.setLineWrap(LINE_WRAP);
+        super.setWrapStyleWord(WRAP_STYLE_WORD);
+        this.disableUndo = disableUndo;
+        if (USER_FONT_FAMILY != null) {
+            int fontSize = USER_FONT_SIZE > 0 ? USER_FONT_SIZE : getFont().getSize();
+            setFont(new Font(USER_FONT_FAMILY, Font.PLAIN, fontSize));
+            if (log.isDebugEnabled()) {
+                log.debug("Font is set to: {}", getFont());
+            }
+        }
+        if(disableUndo) {
+            // We need to do this to force recreation of undoManager which
+            // will use the disableUndo otherwise it would always be false
+            // See BUG 57440
+            discardAllEdits();
+        }
+    }
+
+    /**
+     * Sets the language of the text area.
+     * 
+     * @param language
+     *            The language to be set
+     */
+    public void setLanguage(String language) {
+        if(language == null) {
+          // TODO: Log a message?
+          // But how to find the name of the offending GUI element in the case of a TestBean?
+          super.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_NONE);
+        } else {
+          final String style = languageProperties.getProperty(language);
+          if (style == null) {
+              super.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_NONE);
+          } else {
+              super.setSyntaxEditingStyle(style);
+          }
+        }
+    }
+
+    /**
+     * Override UndoManager to allow disabling if feature causes issues
+     * See <a href="https://github.com/bobbylight/RSyntaxTextArea/issues/19">Issue 19 on RSyntaxTextArea</a>
+     */
+    @Override
+    protected RUndoManager createUndoManager() {
+        RUndoManager undoManager = super.createUndoManager();
+        if(disableUndo) {
+            undoManager.setLimit(0);
+        } else {
+            undoManager.setLimit(MAX_UNDOS);
+        }
+        return undoManager;
+    }
+
+    /**
+     * Sets initial text resetting undo history
+     * 
+     * @param string
+     *            The initial text to be set
+     */
+    public void setInitialText(String string) {
+        setText(string);
+        discardAllEdits();
+    }
+    
+
+    private static final Theme initTheme() {
+        try {
+            return Theme.load(JSyntaxTextArea.class.getClassLoader().getResourceAsStream(
+                    "org/apache/jmeter/gui/util/theme/darcula_theme.xml"));
+        } catch (IOException e) {
+            log.error("Error reading darcula_theme for JSyntaxTextArea", e);
+            return null;
+        }
+    }
+}

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
@@ -20,13 +20,11 @@ package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
 
 import java.awt.Font;
 import java.awt.HeadlessException;
-import java.io.IOException;
 import java.util.Properties;
 
 import org.apache.jmeter.util.JMeterUtils;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
-import org.fife.ui.rsyntaxtextarea.Theme;
 import org.fife.ui.rtextarea.RUndoManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +33,12 @@ import org.slf4j.LoggerFactory;
  * Utility class to handle RSyntaxTextArea code
  * It's not currently possible to instantiate the RSyntaxTextArea class when running headless.
  * So we use getInstance methods to create the class and allow for headless testing.
+ * FIXME REMOVE WHEN UPGRADE TO 3.0
  */
 class JSyntaxTextArea extends RSyntaxTextArea {
 
     private static final long serialVersionUID = 211L;
     private static final Logger log              = LoggerFactory.getLogger(JSyntaxTextArea.class);
-
-    private static final Theme DARCULA_THEME = initTheme(); 
 
     private final Properties languageProperties = JMeterUtils.loadProperties("org/apache/jmeter/gui/util/textarea.properties"); //$NON-NLS-1$
 
@@ -252,16 +249,5 @@ class JSyntaxTextArea extends RSyntaxTextArea {
     public void setInitialText(String string) {
         setText(string);
         discardAllEdits();
-    }
-    
-
-    private static final Theme initTheme() {
-        try {
-            return Theme.load(JSyntaxTextArea.class.getClassLoader().getResourceAsStream(
-                    "org/apache/jmeter/gui/util/theme/darcula_theme.xml"));
-        } catch (IOException e) {
-            log.error("Error reading darcula_theme for JSyntaxTextArea", e);
-            return null;
-        }
     }
 }

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JSyntaxTextArea.java
@@ -70,8 +70,7 @@ class JSyntaxTextArea extends RSyntaxTextArea {
      */
     public static JSyntaxTextArea getInstance(int rows, int cols, boolean disableUndo) {
         try {
-            JSyntaxTextArea jSyntaxTextArea = new JSyntaxTextArea(rows, cols, disableUndo);
-            return jSyntaxTextArea;
+            return new JSyntaxTextArea(rows, cols, disableUndo);
         } catch (HeadlessException e) {
             // Allow override for unit testing only
             if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
@@ -88,11 +87,17 @@ class JSyntaxTextArea extends RSyntaxTextArea {
                     }
                     // Override methods that would fail
                     @Override
-                    public void setCodeFoldingEnabled(boolean b) {  }
+                    public void setCodeFoldingEnabled(boolean b) { 
+                        // NOOP
+                    }
                     @Override
-                    public void setCaretPosition(int b) { }
+                    public void setCaretPosition(int b) { 
+                        // NOOP
+                    }
                     @Override
-                    public void discardAllEdits() { }
+                    public void discardAllEdits() {
+                        // NOOP
+                    }
                     @Override
                     public void setText(String t) {
                         this.text = t;
@@ -212,7 +217,6 @@ class JSyntaxTextArea extends RSyntaxTextArea {
      */
     public void setLanguage(String language) {
         if(language == null) {
-          // TODO: Log a message?
           // But how to find the name of the offending GUI element in the case of a TestBean?
           super.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_NONE);
         } else {

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JTextScrollPane.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/JTextScrollPane.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
+
+import org.fife.ui.rtextarea.RTextScrollPane;
+
+
+/**
+ * Utility class to handle RSyntaxTextArea code
+ * It's not currently possible to instantiate the RTextScrollPane class when running headless.
+ * So we use getInstance methods to create the class and allow for headless testing.
+ * TODO : Remove when upgrading to JMeter 3.0
+ */
+class JTextScrollPane extends RTextScrollPane {
+
+    private static final long serialVersionUID = 210L;
+
+    @Deprecated
+    public JTextScrollPane() {
+        // for use by test code only
+    }
+
+    public static JTextScrollPane getInstance(JSyntaxTextArea scriptField, boolean foldIndicatorEnabled) {
+        try {
+            return new JTextScrollPane(scriptField, foldIndicatorEnabled);
+        } catch (NullPointerException npe) { // for headless unit testing
+            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
+                return new JTextScrollPane();                
+            } else {
+                throw npe;
+            }
+        }
+    }
+
+    public static JTextScrollPane getInstance(JSyntaxTextArea scriptField) {
+        try {
+            return new JTextScrollPane(scriptField);
+        } catch (NullPointerException npe) { // for headless unit testing
+            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
+                return new JTextScrollPane();                
+            } else {
+                throw npe;
+            }
+        }
+    }
+
+    /**
+     * @param scriptField syntax text are to wrap
+     * @deprecated use {@link #getInstance(JSyntaxTextArea)} instead
+     */
+    @Deprecated
+    public JTextScrollPane(JSyntaxTextArea scriptField) {
+        super(scriptField);
+    }
+
+    /**
+     * 
+     * @param scriptField syntax text are to wrap
+     * @param foldIndicatorEnabled flag, whether fold indicator should be enabled
+     * @deprecated use {@link #getInstance(JSyntaxTextArea, boolean)} instead
+     */
+    @Deprecated
+    public JTextScrollPane(JSyntaxTextArea scriptField, boolean foldIndicatorEnabled) {
+        super(scriptField);
+        super.setFoldIndicatorEnabled(foldIndicatorEnabled);
+    }
+
+}

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
@@ -2,7 +2,6 @@ package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Font;
-import java.awt.HeadlessException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -14,8 +13,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
-import org.apache.jmeter.gui.util.JSyntaxTextArea;
-import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JSR223BeanInfoSupport;
@@ -30,7 +27,7 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
 
     JTextField parameters;
 
-    JSyntaxTextArea script;
+    com.googlecode.jmeter.plugins.webdriver.sampler.gui.JSyntaxTextArea script;
     JComboBox<String> languages;
 
     public WebDriverSamplerGui() {
@@ -145,8 +142,8 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
     }
 
     private JPanel createScriptPanel() {
-        script =  getInstance(25, 80, false);
-        final JScrollPane scrollPane = getInstance(script, true);
+        script =  JSyntaxTextArea.getInstance(25, 80, false);
+        final JScrollPane scrollPane = JTextScrollPane.getInstance(script, true);
         setScriptContentType("text");
         script.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
 
@@ -164,78 +161,5 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
         panel.add(explain, BorderLayout.SOUTH);
 
         return panel;
-    }
-    
-    /**
-     * Creates the default syntax highlighting text area. The following are set:
-     * <ul>
-     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
-     * <li>setCodeFoldingEnabled(true)</li>
-     * <li>setAntiAliasingEnabled(true)</li>
-     * <li>setLineWrap(true)</li>
-     * <li>setWrapStyleWord(true)</li>
-     * </ul>
-     * TODO Remove when upgrade to minimum 3.0
-     * @param rows
-     *            The number of rows for the text area
-     * @param cols
-     *            The number of columns for the text area
-     * @param disableUndo
-     *            true to disable undo manager
-     * @return {@link JSyntaxTextArea}
-     */
-    private static JSyntaxTextArea getInstance(int rows, int cols, boolean disableUndo) {
-        try {
-            return new JSyntaxTextArea(rows, cols, disableUndo);
-        } catch (HeadlessException e) {
-            // Allow override for unit testing only
-            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
-                return new JSyntaxTextArea() {
-                    private static final long serialVersionUID = 1L;
-                    @Override
-                    protected void init() {
-                        try {
-                            super.init();
-                        } catch (HeadlessException|NullPointerException e) {
-                            // ignored
-                        }
-                    }
-                    // Override methods that would fail
-                    @Override
-                    public void setCodeFoldingEnabled(boolean b) { 
-                        // NOOP
-                    }
-                    @Override
-                    public void setCaretPosition(int b) { 
-                        // NOOP
-                    }
-                    @Override
-                    public void discardAllEdits() {
-                        // NOOP    
-                    }
-                    @Override
-                    public void setText(String t) { 
-                        // NOOP
-                    }
-                    @Override
-                    public boolean isCodeFoldingEnabled(){ return true; }
-                };
-            } else {
-                throw e;
-            }
-        }
-    }
-    
-    // TODO Remove when upgrade to minimum 3.0
-    private static JTextScrollPane getInstance(JSyntaxTextArea scriptField, boolean foldIndicatorEnabled) {
-        try {
-            return new JTextScrollPane(scriptField, foldIndicatorEnabled);
-        } catch (NullPointerException npe) { // for headless unit testing
-            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
-                return new JTextScrollPane();                
-            } else {
-                throw npe;
-            }
-        }
     }
 }

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
@@ -1,35 +1,36 @@
 package com.googlecode.jmeter.plugins.webdriver.sampler.gui;
 
-import com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler;
-import jsyntaxpane.DefaultSyntaxKit;
-import kg.apc.jmeter.JMeterPluginsUtils;
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.awt.HeadlessException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.Box;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+
+import org.apache.jmeter.gui.util.JSyntaxTextArea;
+import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JSR223BeanInfoSupport;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import com.googlecode.jmeter.plugins.webdriver.sampler.WebDriverSampler;
+
+import kg.apc.jmeter.JMeterPluginsUtils;
 
 public class WebDriverSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 100L;
-    private static final Logger LOGGER = LoggingManager.getLoggerForClass();
-
-    static {
-        if (!GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance()) {
-            DefaultSyntaxKit.initKit();
-        } else {
-            LOGGER.info("Headless environment detected. Disabling JSyntaxPane highlighting.");
-        }
-    }
 
     JTextField parameters;
 
-    JEditorPane script;
+    JSyntaxTextArea script;
     JComboBox<String> languages;
 
     public WebDriverSamplerGui() {
@@ -118,14 +119,14 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
             langs[n] = languageNames[n][0];
         }
 
-        languages = new JComboBox<String>(langs);
+        languages = new JComboBox<>(langs);
         languages.setName(WebDriverSampler.PARAMETERS);
         label.setLabelFor(languages);
         languages.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 JComboBox<String> source = (JComboBox<String>) actionEvent.getSource();
-                String ctype = "text/" + source.getSelectedItem();
+                String ctype = (String)source.getSelectedItem();
                 setScriptContentType(ctype);
             }
         });
@@ -139,14 +140,14 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
 
     private void setScriptContentType(String ctype) {
         String text = script.getText();
-        script.setContentType(ctype);
+        script.setLanguage(ctype.toLowerCase());
         script.setText(text);
     }
 
     private JPanel createScriptPanel() {
-        script = new JEditorPane();
-        final JScrollPane scrollPane = new JScrollPane(script);
-        setScriptContentType("text/plain");
+        script =  getInstance(25, 80, false);
+        final JScrollPane scrollPane = getInstance(script, true);
+        setScriptContentType("text");
         script.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
 
         final JLabel label = new JLabel("Script (see below for variables that are defined)");
@@ -163,5 +164,71 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
         panel.add(explain, BorderLayout.SOUTH);
 
         return panel;
+    }
+    
+    /**
+     * Creates the default syntax highlighting text area. The following are set:
+     * <ul>
+     * <li>setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JAVA)</li>
+     * <li>setCodeFoldingEnabled(true)</li>
+     * <li>setAntiAliasingEnabled(true)</li>
+     * <li>setLineWrap(true)</li>
+     * <li>setWrapStyleWord(true)</li>
+     * </ul>
+     * TODO Remove when upgrade to minimum 3.0
+     * @param rows
+     *            The number of rows for the text area
+     * @param cols
+     *            The number of columns for the text area
+     * @param disableUndo
+     *            true to disable undo manager
+     * @return {@link JSyntaxTextArea}
+     */
+    private static JSyntaxTextArea getInstance(int rows, int cols, boolean disableUndo) {
+        try {
+            JSyntaxTextArea jSyntaxTextArea = new JSyntaxTextArea(rows, cols, disableUndo);
+            return jSyntaxTextArea;
+        } catch (HeadlessException e) {
+            // Allow override for unit testing only
+            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
+                return new JSyntaxTextArea() {
+                    private static final long serialVersionUID = 1L;
+                    @Override
+                    protected void init() {
+                        try {
+                            super.init();
+                        } catch (HeadlessException|NullPointerException e) {
+                            // ignored
+                        }
+                    }
+                    // Override methods that would fail
+                    @Override
+                    public void setCodeFoldingEnabled(boolean b) {  }
+                    @Override
+                    public void setCaretPosition(int b) { }
+                    @Override
+                    public void discardAllEdits() { }
+                    @Override
+                    public void setText(String t) { }
+                    @Override
+                    public boolean isCodeFoldingEnabled(){ return true; }
+                };
+            } else {
+                throw e;
+            }
+        }
+    }
+    
+    // TODO Remove when upgrade to minimum 3.0
+    private static JTextScrollPane getInstance(JSyntaxTextArea scriptField, boolean foldIndicatorEnabled) {
+        try {
+            return new JTextScrollPane(scriptField, foldIndicatorEnabled);
+        } catch (NullPointerException npe) { // for headless unit testing
+            if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
+                return new JTextScrollPane();                
+            } else {
+                throw npe;
+            }
+        }
     }
 }

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/gui/WebDriverSamplerGui.java
@@ -186,8 +186,7 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
      */
     private static JSyntaxTextArea getInstance(int rows, int cols, boolean disableUndo) {
         try {
-            JSyntaxTextArea jSyntaxTextArea = new JSyntaxTextArea(rows, cols, disableUndo);
-            return jSyntaxTextArea;
+            return new JSyntaxTextArea(rows, cols, disableUndo);
         } catch (HeadlessException e) {
             // Allow override for unit testing only
             if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
@@ -203,13 +202,21 @@ public class WebDriverSamplerGui extends AbstractSamplerGui {
                     }
                     // Override methods that would fail
                     @Override
-                    public void setCodeFoldingEnabled(boolean b) {  }
+                    public void setCodeFoldingEnabled(boolean b) { 
+                        // NOOP
+                    }
                     @Override
-                    public void setCaretPosition(int b) { }
+                    public void setCaretPosition(int b) { 
+                        // NOOP
+                    }
                     @Override
-                    public void discardAllEdits() { }
+                    public void discardAllEdits() {
+                        // NOOP    
+                    }
                     @Override
-                    public void setText(String t) { }
+                    public void setText(String t) { 
+                        // NOOP
+                    }
                     @Override
                     public boolean isCodeFoldingEnabled(){ return true; }
                 };


### PR DESCRIPTION
…tead of JEditor

This PR fixes the bug reported on google group.
Sampler has possibility to select an alternative to javascript, but when you select Groovy
an error occurs when selecting another element and then select WDS again, see attached screenshot.

Issue was due to DefaultSyntaxKit.initKit(). 
So I switched to the JSyntaxtTextArea component which is anyway more uniform.
Note that it would be nice to drop 2.13 support which would allow using JMeter core JSyntaxTextArea#getInstance() which will handle correctly the new Darcula LAF.

Regards
Philippe M. from UbikLoadPack Team