### PR TITLE
Version 2.1.1 - ElasticSearch Backend Listener

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -410,7 +410,10 @@
       "2.1.0": {
         "changes": "Added metrics, fixed bugs, added logging, and added timeout to avoid hanging requests.",
         "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.1.0/jmeter.backendlistener.elasticsearch-2.1.0.jar"
-        
+      },
+      "2.1.1": {
+        "changes": "Reduction of the JAR.",
+        "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.1.1/jmeter.backendlistener.elasticsearch-2.1.1.jar"
       }
     }
   }

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -406,6 +406,11 @@
       "2.0.1": {
           "changes": "Performance tuning, refactor & sends results to ElasticSearch in bulk",
           "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.0.1/jmeter.backendlistener.elasticsearch-2.0.1.jar"
+      },
+      "2.1.0": {
+        "changes": "Added metrics, fixed bugs, added logging, and added timeout to avoid hanging requests.",
+        "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.1.0/jmeter.backendlistener.elasticsearch-2.1.0.jar"
+        
       }
     }
   }


### PR DESCRIPTION
* Added use of assertionArray
* getElapsedTime now returns a generic date for comparison in Jenkins AND the elapsed time according to today.
* Added "sentBytes" metric
* ResponseTime uses the getTime() method
* Added timeout to avoid hanging requests
* Corrected formatting of dates
* Added logging in case of failures