### PR TITLE
Added 2.2.1 and removed everything below 2.1.0

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -380,44 +380,12 @@
   {
     "id": "jmeter.backendlistener.elasticsearch",
     "name": "ElasticSearch backend listener",
-    "description": "Apache JMeter plugin for sending sample results to an ElasticSearch engine. <ul><li>Simply add a \"Backend Listener\" and change the implementation</li><li>Change the listener's configuration</li></ul>",
+    "description": "Apache JMeter plugin for sending sample results to an ElasticSearch engine. <ul><li>Simply add a \"Backend Listener\" and change the implementation</li><li>Change the listener's configuration</li><li>To use filters, simple seperate their name by a semicolon. (f1;f2;f3)</li></ul>",
     "helpUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/issues",
     "screenshotUrl": "",
     "vendor": "Delirius325",
     "markerClass": "net.delirius.jmeter.backendlistener.elasticsearch.ElasticsearchBackend",
     "versions": {
-      "1.0": {
-        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/1.0/elasticsearch-backend-listener-1.0.jar"
-      },
-      "1.5": {
-        "changes": "Added option to trust all SSL certificates. *Be careful with this, it should never be used in production*",
-        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/1.5.0/elasticsearch-backend-listener-1.5.jar"
-      },
-      "1.5.2": {
-        "changes": "Fixed a bug where long test runs would trigger a crash caused by the connection pool of the OkHttp client",
-        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/1.5.2/elasticsearch-backend-listener-1.5.2.jar"
-      },
-      "1.5.3": {
-        "changes": "Refactored most of the plugin",
-        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/1.5.3/elasticsearch-backend-listener-1.5.3.jar",
-        "libs": {
-          "gson": "https://search.maven.org/remotecontent?filepath=com/google/code/gson/gson/2.8.2/gson-2.8.2.jar",
-          "okhttp": "https://search.maven.org/remotecontent?filepath=com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar",
-          "okio": "https://search.maven.org/remotecontent?filepath=com/squareup/okio/okio/1.13.0/okio-1.13.0.jar"
-        }
-      },
-      "2.0.0": {
-          "changes": "Complete refactoring of plugin, switched from OkHttp calls to ElasticSearch 5.5.2 native API calls",
-          "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.0.0/jmeter.backendlistener.elasticsearch-2.0.0.jar"
-      },
-      "2.0.1": {
-          "changes": "Performance tuning, refactor & sends results to ElasticSearch in bulk",
-          "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.0.1/jmeter.backendlistener.elasticsearch-2.0.1.jar"
-      },
-      "2.0.2": {
-        "changes": "Rare null pointer exception fix & removed useless fields",
-        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.0.2/jmeter.backendlistener.elasticsearch-2.0.2.jar"
-      },
       "2.1.0": {
         "changes": "Added metrics, fixed bugs, added logging, and added timeout to avoid hanging requests.",
         "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.1.0/jmeter.backendlistener.elasticsearch-2.1.0.jar"
@@ -429,6 +397,10 @@
       "2.2.0": {
         "changes": "Makes use of the ElasticSearch low-level REST client. The plugin now works with any version of ElasticSearch.",
         "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.2.0/jmeter.backendlistener.elasticsearch-2.2.0.jar"
+      },
+      "2.2.1": {
+        "changes": "Added filters",
+        "downloadUrl":"https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.2.1/jmeter.backendlistener.elasticsearch-2.2.1.jar"
       }
     }
   }


### PR DESCRIPTION
Versions below 2.1.0 are deprecated and should be updated to the latest. Also added version 2.2.1 which includes sampler filtering before sending to ElasticSearch.