### PR TITLE
Try to cleanly stop threads before doing it abruptly to avoid pending samplers being interrupted

### DIFF
--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -97,7 +97,7 @@ public class VariableThroughputTimer
             try {
                 wait(delayMs);
             } catch (InterruptedException ex) {
-                log.error("Waiting thread was interrupted", ex);
+                log.debug("Waiting thread was interrupted", ex);
                 Thread.currentThread().interrupt();
             }
             cntDelayed--;

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -310,10 +310,14 @@ public class VariableThroughputTimer
         } else if (stopTries > 5) {
             log.info("Tries more than 5, shutting down engine!");
             StandardJMeterEngine.stopEngine();
+        } else if (stopTries > 3) {
+            AbstractThreadGroup threadGroup = JMeterContextService.getContext().getThreadGroup();
+            log.info("Hard stopping threads of Thread Group : {}", threadGroup.getName());
+            threadGroup.tellThreadsToStop();
         } else {
             AbstractThreadGroup threadGroup = JMeterContextService.getContext().getThreadGroup();
-            log.info("Stopping threads of Thread Group : {}", threadGroup.getName());
-            threadGroup.tellThreadsToStop();
+            log.info("Stopping gracefuly threads of Thread Group : {}", threadGroup.getName());
+            threadGroup.stop();
         }
     }
 

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -312,7 +312,7 @@ public class VariableThroughputTimer
             StandardJMeterEngine.stopEngine();
         } else if (stopTries > 3) {
             AbstractThreadGroup threadGroup = JMeterContextService.getContext().getThreadGroup();
-            log.info("Hard stopping threads of Thread Group : {}", threadGroup.getName());
+            log.info("Tries more than 3, hard stopping threads of Thread Group : {}", threadGroup.getName());
             threadGroup.tellThreadsToStop();
         } else {
             AbstractThreadGroup threadGroup = JMeterContextService.getContext().getThreadGroup();

--- a/site/dat/wiki/ThroughputShapingTimer.wiki
+++ b/site/dat/wiki/ThroughputShapingTimer.wiki
@@ -39,6 +39,24 @@ Shaping Timer setting in example test plan:
 Actual RPS provided:
 [/img/wiki/throughput_shaping_timer2.png]
 
+== Properties exposed by Component ==
+
+The element will export the following properties that you can access through [https://jmeter.apache.org/usermanual/functions.html#__P] function or 
+using in JSR223 Test Elements:
+
+<code>
+props.get("property name")
+</code>
+
+Properties are:
+
+* elementName_totalDuration  - Total duration as sum of the "Duration,sec" column
+* elementName_cntDelayed - Number of current threads waiting, if lower than 1 it means we don't have enough threads to reach RPS
+* elementName_cntSent - Number of samples sent since last second tick
+* elementName_rps - Current RPS
+
+elementName will be the name of your Timer
+
 == Special Property Processing ==
 
 There is a way to specify load pattern from special jmeter property {{{load_profile}}}.


### PR DESCRIPTION
Currently in logs we have:

2018-03-09 11:45:58,017 ERROR k.a.j.t.VariableThroughputTimer: Waiting thread was interrupted
java.lang.InterruptedException: null
	at java.lang.Object.wait(Native Method) ~[?:1.8.0_131]
	at kg.apc.jmeter.timers.VariableThroughputTimer.delay(VariableThroughputTimer.java:98) [jmeter-plugins-tst-2.2.jar:?]
	at org.apache.jmeter.threads.JMeterThread.delay(JMeterThread.java:857) [ApacheJMeter_core.jar:4.0 r1823414]
	at org.apache.jmeter.threads.JMeterThread.executeSamplePackage(JMeterThread.java:472) [ApacheJMeter_core.jar:4.0 r1823414]
	at org.apache.jmeter.threads.JMeterThread.processSampler(JMeterThread.java:416) [ApacheJMeter_core.jar:4.0 r1823414]
	at org.apache.jmeter.threads.JMeterThread.run(JMeterThread.java:250) [ApacheJMeter_core.jar:4.0 r1823414]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]

Which is disturbing.
