### PR TITLE
More details when not enough threads

### DIFF
--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -144,7 +144,8 @@ public class VariableThroughputTimer
         }
 
         if (cntDelayed < 1) {
-            log.warn("No free threads available in current Thread Group, made {} samples/s for expected rps {} samples/s, increase your number of threads", cntSent, rps);
+            log.warn("No free threads available in current Thread Group {}, made {} samples/s for expected rps {} samples/s, increase your number of threads", 
+                    JMeterContextService.getContext().getThreadGroup().getName(), cntSent, rps);
         }
 
         String elementName = getName();
@@ -160,7 +161,7 @@ public class VariableThroughputTimer
     /**
      * 
      * @param millisSinceLastSecond Millis since last second tick
-     * @return delay to apply at current millis, < 0 if no delay
+     * @return delay in Millis to apply at current millis, < 0 if no delay
      */
     private int getDelay(long millisSinceLastSecond) {
         if(log.isDebugEnabled()) {
@@ -168,6 +169,7 @@ public class VariableThroughputTimer
         }
         if (millisSinceLastSecond < (cntSent * msecPerReq)) {
             // TODO : Explain this for other maintainers
+            // cntDelayed + 1 : Current threads waiting + this thread
             return (int) (1 + 1000.0 * (cntDelayed + 1) / rps);
         }
         // we're under rate

--- a/site/dat/wiki/ThroughputShapingTimer.wiki
+++ b/site/dat/wiki/ThroughputShapingTimer.wiki
@@ -39,6 +39,24 @@ Shaping Timer setting in example test plan:
 Actual RPS provided:
 [/img/wiki/throughput_shaping_timer2.png]
 
+== Properties exposed by Component ==
+
+The element will export the following properties that you can access through [https://jmeter.apache.org/usermanual/functions.html#__P] function or 
+using in JSR223 Test Elements:
+
+<code>
+props.get("property name")
+</code>
+
+Properties are:
+
+* elementName_totalDuration  - Total duration as sum of the "Duration,sec" column
+* elementName_cntDelayed - Number of current threads waiting, if lower than 1 it means we don't have enough threads to reach RPS
+* elementName_cntSent - Number of samples sent since last second tick
+* elementName_rps - Current RPS
+
+elementName will be the name of your Timer
+
 == Special Property Processing ==
 
 There is a way to specify load pattern from special jmeter property {{{load_profile}}}.


### PR DESCRIPTION
Warning "No free threads available in current Thread Group" does not indicate which thread group is concerned.

Add this information.