### PR TITLE
Version 2.3.0 - ElasticSearch Backend Listener

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -430,6 +430,10 @@
       "2.2.5": {
         "changes": "Added request body in info/debug mode -- Forced lowercase for index creation",
         "downloadUrl":"https://search.maven.org/remotecontent?filepath=io/github/delirius325/jmeter.backendlistener.elasticsearch/2.2.5/jmeter.backendlistener.elasticsearch-2.2.5.jar"
+      },
+      "2.3.0": {
+        "changes": "Added a new detail mode : 'error' - only send the failing samplers to ElasticSearch",
+        "downloadUrl": "https://oss.sonatype.org/service/local/repositories/releases/content/io/github/delirius325/jmeter.backendlistener.elasticsearch/2.3.0/jmeter.backendlistener.elasticsearch-2.3.0.jar"
       }
     }
   }


### PR DESCRIPTION
Added a new detail mode : "error" - only send the falling samplers to ElasticSearch