### PR TITLE
Added ES Backend Listener 2.2.3 back

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -406,6 +406,10 @@
     "vendor": "Delirius325",
     "markerClass": "io.github.delirius325.jmeter.backendlistener.elasticsearch.ElasticsearchBackend",
     "versions": {
+      "2.2.3": {
+        "changes": "DEPRECATED. Added back because of an issue with the plugins manager not uninstalling it.",
+        "downloadUrl":"https://search.maven.org/remotecontent?filepath=io/github/delirius325/jmeter.backendlistener.elasticsearch/2.2.3/jmeter.backendlistener.elasticsearch-2.2.3.jar"
+      },
       "2.2.5": {
         "changes": "Added request body in info/debug mode -- Forced lowercase for index creation",
         "downloadUrl":"https://search.maven.org/remotecontent?filepath=io/github/delirius325/jmeter.backendlistener.elasticsearch/2.2.5/jmeter.backendlistener.elasticsearch-2.2.5.jar"


### PR DESCRIPTION
Added version 2.2.3 back for compatibility issues. People with older versions of the plugin won't be able to upgrade to the newest version.