### PR TITLE
Add Option to permit Insecure Certs in ChromeHeadless

### DIFF
--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
@@ -25,6 +25,7 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
     private static final String CHROME_SERVICE_PATH = "ChromeDriverConfig.chromedriver_path";
     private static final String ANDROID_ENABLED = "ChromeDriverConfig.android_enabled";
     private static final String HEADLESS_ENABLED = "ChromeDriverConfig.headless_enabled";
+    private static final String INSECURECERTS_ENABLED = "ChromeDriverConfig.insecurecerts_enabled";
     private static final Map<String, ChromeDriverService> services = new ConcurrentHashMap<String, ChromeDriverService>();
 
     public void setChromeDriverPath(String path) {
@@ -52,9 +53,13 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
             }
             if (isHeadlessEnabled()) {
                 chromeOptions.addArguments("--headless");
+
             }
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
         }
+	if(isInsecureCertsEnabled()) {
+	        capabilities.setCapability("acceptInsecureCerts", true);
+	}
 
         return capabilities;
     }
@@ -108,5 +113,13 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
 
     public void setHeadlessEnabled(boolean enabled) {
         setProperty(HEADLESS_ENABLED, enabled);
+    }
+
+    public boolean isInsecureCertsEnabled() {
+        return getPropertyAsBoolean(INSECURECERTS_ENABLED);
+    }
+
+    public void setInsecureCertsEnabled(boolean enabled) {
+        setProperty(INSECURECERTS_ENABLED, enabled);
     }
 }

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
@@ -14,6 +14,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
     JTextField chromeServicePath;
     JCheckBox androidEnabled;
     private JCheckBox headlessEnabled;
+    private JCheckBox insecureCertsEnabled;
 
     @Override
     public String getStaticLabel() {
@@ -33,6 +34,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             chromeServicePath.setText(config.getChromeDriverPath());
             androidEnabled.setSelected(config.isAndroidEnabled());
             getHeadlessEnabled().setSelected(config.isHeadlessEnabled());
+            getInsecureCertsEnabled().setSelected(config.isInsecureCertsEnabled());
         }
     }
 
@@ -51,6 +53,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             config.setChromeDriverPath(chromeServicePath.getText());
             config.setAndroidEnabled(androidEnabled.isSelected());
             config.setHeadlessEnabled(getHeadlessEnabled().isSelected());
+            config.setInsecureCertsEnabled(getInsecureCertsEnabled().isSelected());
         }
     }
 
@@ -60,6 +63,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
         chromeServicePath.setText("");
         androidEnabled.setSelected(false);
         getHeadlessEnabled().setSelected(false);
+        getInsecureCertsEnabled().setSelected(false);
     }
 
     @Override
@@ -92,6 +96,9 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
         headlessEnabled = new JCheckBox("Use Chrome headless mode");
         browserPanel.add(getHeadlessEnabled());
+
+        insecureCertsEnabled = new JCheckBox("Allow Insecure Certs");
+        browserPanel.add(getInsecureCertsEnabled());
         return browserPanel;
     }
 
@@ -107,5 +114,9 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
     public JCheckBox getHeadlessEnabled() {
         return headlessEnabled;
+    }
+    
+    public JCheckBox getInsecureCertsEnabled() {
+        return insecureCertsEnabled;
     }
 }

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -154,6 +154,21 @@ public class ChromeDriverConfigTest {
         assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(nullValue()));
     }
 
+
+    @Test
+    public void shouldHaveInsecureCertsWhenInsecureCertsIsEnabled() {
+        config.setInsecureCertsEnabled(true);
+        final Capabilities capabilities = config.createCapabilities();
+        assertThat((Boolean) capabilities.getCapability("acceptInsecureCerts"), is(true));
+    }
+
+    @Test
+    public void shouldNotHaveInsecureCertsWhenInsecureCertsIsNotEnabled() {
+        config.setInsecureCertsEnabled(false);
+        final Capabilities capabilities = config.createCapabilities();
+        assertThat(capabilities.getCapability("acceptInsecureCerts"), is(nullValue()));
+    }
+
     @Test
     public void shouldHaveAndroidConfigWhenAndroidIsEnabled() {
         config.setAndroidEnabled(true);

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -185,4 +185,11 @@ public class ChromeDriverConfigTest {
         config.setHeadlessEnabled(true);
         assertThat(config.isHeadlessEnabled(), is(true));
     }
+
+    @Test
+    public void getSetInsecureCertsEnabled() {
+        assertThat(config.isInsecureCertsEnabled(), is(false));
+        config.setInsecureCertsEnabled(true);
+        assertThat(config.isInsecureCertsEnabled(), is(true));
+    }
 }

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
@@ -65,16 +65,25 @@ public class ChromeDriverConfigGuiTest {
     }
 
     @Test
+    public void shouldSetInsecureCertsEnabled() {
+        gui.getInsecureCertsEnabled().setSelected(true);
+        final ChromeDriverConfig testElement = (ChromeDriverConfig) gui.createTestElement();
+        assertThat(testElement.isInsecureCertsEnabled(), is(true));
+    }
+
+    @Test
     public void shouldResetValuesOnClearGui() {
         gui.chromeServicePath.setText("path");
         gui.androidEnabled.setSelected(true);
         gui.getHeadlessEnabled().setSelected(true);
+        gui.getInsecureCertsEnabled().setSelected(true);
 
         gui.clearGui();
 
         assertThat(gui.chromeServicePath.getText(), is(""));
         assertThat(gui.androidEnabled.isSelected(), is(false));
         assertThat(gui.getHeadlessEnabled().isSelected(), is(false));
+        assertThat(gui.getInsecureCertsEnabled().isSelected(), is(false));
     }
 
     @Test
@@ -102,6 +111,15 @@ public class ChromeDriverConfigGuiTest {
         gui.configure(config);
 
         assertThat(gui.getHeadlessEnabled().isSelected(), is(config.isHeadlessEnabled()));
+    }
+
+    @Test
+    public void shouldSetInsecureCertsEnabledOnConfigure() {
+        ChromeDriverConfig config = new ChromeDriverConfig();
+        config.setInsecureCertsEnabled(true);
+        gui.configure(config);
+
+        assertThat(gui.getInsecureCertsEnabled().isSelected(), is(config.isInsecureCertsEnabled()));
     }
 
     @Test


### PR DESCRIPTION
This expands on the ChromeDriver work in https://bugs.chromium.org/p/chromium/issues/detail?id=721739 to support Chrome Headless running in an environment with e.g. self-signed certs.