### PR TITLE
Remote file detector option

### DIFF
--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FileDetectorOption.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FileDetectorOption.java
@@ -1,0 +1,32 @@
+package com.googlecode.jmeter.plugins.webdriver.config;
+
+import org.openqa.selenium.remote.FileDetector;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.UselessFileDetector;
+
+public enum FileDetectorOption {
+	LOCAL("Local file detector", LocalFileDetector.class),
+	USELESS("Useless file detector", UselessFileDetector.class);
+
+	private final String name;
+
+	private final Class<? extends FileDetector> clazz;
+
+	FileDetectorOption(String name, Class<? extends FileDetector> clazz) {
+		this.name = name;
+		this.clazz = clazz;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Class<? extends FileDetector> getClazz() {
+		return clazz;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+}

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
@@ -66,7 +66,7 @@ public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 		setProperty(REMOTE_FILE_DETECTOR, fileDetectorOption.name());
 	}
 
-	private FileDetector createFileDetector() {
+	protected FileDetector createFileDetector() {
 		try {
 			return getFileDetectorOption().getClazz().newInstance();
 		} catch (Exception e) {

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
@@ -1,47 +1,50 @@
 package com.googlecode.jmeter.plugins.webdriver.config;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.*;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.remote.CapabilityType;
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
-
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteCapability;
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteDesiredCapabilitiesFactory;
-import com.googlecode.jmeter.plugins.webdriver.config.WebDriverConfig;
-
 public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 
-    private static final long serialVersionUID = 100L;
-    private static final String REMOTE_SELENIUM_GRID_URL = "RemoteDriverConfig.general.selenium.grid.url";
-    private static final String REMOTE_CAPABILITY = "RemoteDriverConfig.general.selenium.capability";
+	private static final long serialVersionUID = 100L;
+	private static final String REMOTE_SELENIUM_GRID_URL = "RemoteDriverConfig.general.selenium.grid.url";
+	private static final String REMOTE_CAPABILITY = "RemoteDriverConfig.general.selenium.capability";
+	private static final String REMOTE_FILE_DETECTOR = "RemoteDriverConfig.general.selenium.file.detector";
 
-    Capabilities createCapabilities() {
-    	DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(getCapability());
-        capabilities.setCapability(CapabilityType.PROXY, createProxy());
-        capabilities.setJavascriptEnabled(true);
-        return capabilities;
-    }
+	private static final Logger LOGGER = LoggingManager.getLoggerForClass();
 
-    @Override
-    protected RemoteWebDriver createBrowser() {
-    	try {
-			return new RemoteWebDriver(new URL(getSeleniumGridUrl()), createCapabilities());
+	Capabilities createCapabilities() {
+		DesiredCapabilities capabilities = RemoteDesiredCapabilitiesFactory.build(getCapability());
+		capabilities.setCapability(CapabilityType.PROXY, createProxy());
+		capabilities.setJavascriptEnabled(true);
+		return capabilities;
+	}
+
+	@Override
+	protected RemoteWebDriver createBrowser() {
+		try {
+			RemoteWebDriver driver = new RemoteWebDriver(new URL(getSeleniumGridUrl()), createCapabilities());
+			driver.setFileDetector(createFileDetector());
+			LOGGER.debug("Created web driver with " + createFileDetector().getClass().getName());
+			return driver;
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
-    }
+	}
 
 	public void setSeleniumGridUrl(String seleniumUrl) {
 		setProperty(REMOTE_SELENIUM_GRID_URL, seleniumUrl);
 	}
-	
+
 	public String getSeleniumGridUrl() {
 		return getPropertyAsString(REMOTE_SELENIUM_GRID_URL);
 	}
-	
+
 	public RemoteCapability getCapability(){
 		return RemoteCapability.valueOf(getPropertyAsString(REMOTE_CAPABILITY));
 	}
@@ -49,4 +52,27 @@ public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 	public void setCapability(RemoteCapability selectedCapability) {
 		setProperty(REMOTE_CAPABILITY, selectedCapability.name());
 	}
+
+	public FileDetectorOption getFileDetectorOption() {
+		String fileDetectorString = getPropertyAsString(REMOTE_FILE_DETECTOR);
+		if (StringUtils.isBlank(fileDetectorString)) {
+			LOGGER.warn("No remote file detector configured, reverting to default of useless file detector");
+			return FileDetectorOption.USELESS;
+		}
+		return FileDetectorOption.valueOf(fileDetectorString);
+	}
+
+	public void setFileDetectorOption(FileDetectorOption fileDetectorOption) {
+		setProperty(REMOTE_FILE_DETECTOR, fileDetectorOption.name());
+	}
+
+	private FileDetector createFileDetector() {
+		try {
+			return getFileDetectorOption().getClazz().newInstance();
+		} catch (Exception e) {
+			LOGGER.warn("Cannot create a file detector of type " + getFileDetectorOption().getClazz().getCanonicalName() + ", reverting to default of useless file detector");
+			return new UselessFileDetector();
+		}
+	}
+
 }

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
@@ -21,9 +21,10 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
     private static final long serialVersionUID = 100L;
     JTextField remoteSeleniumGridText;
     JComboBox capabilitiesComboBox;
-    JComboBox fileDetectorsComboBox;
     JLabel errorMsg;
-    
+
+    private JComboBox fileDetectorsComboBox;
+
     @Override
     public String getStaticLabel() {
         return JMeterPluginsUtils.prefixLabel("Remote Driver Config");

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
@@ -84,12 +84,12 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         final JLabel remoteUrlLabel = new JLabel();
         final JLabel capabilitiesLabel = new JLabel();
         final JLabel fileDetectorLabel = new JLabel();
-        
-        
+
         remoteUrlLabel.setText("Selenium Grid URL");
         remoteSeleniumGridText = new JTextField();
         remoteSeleniumGridText.setEnabled(true);
         remoteSeleniumGridText.addFocusListener(this);
+
         capabilitiesLabel.setText("Capability");
         capabilitiesComboBox = new JComboBox(RemoteCapability.values());
 

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
@@ -1,31 +1,27 @@
 package com.googlecode.jmeter.plugins.webdriver.config.gui;
 
-import java.awt.Color;
+import com.googlecode.jmeter.plugins.webdriver.config.FileDetectorOption;
+import com.googlecode.jmeter.plugins.webdriver.config.RemoteCapability;
+import com.googlecode.jmeter.plugins.webdriver.config.RemoteDriverConfig;
+import kg.apc.jmeter.JMeterPluginsUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.jmeter.gui.util.VerticalPanel;
+import org.apache.jmeter.testelement.TestElement;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.ItemListener;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-
-import kg.apc.jmeter.JMeterPluginsUtils;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.jmeter.gui.util.VerticalPanel;
-import org.apache.jmeter.testelement.TestElement;
-
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteCapability;
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteDriverConfig;
-
 public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemListener, FocusListener {
 
     private static final long serialVersionUID = 100L;
     JTextField remoteSeleniumGridText;
     JComboBox capabilitiesComboBox;
+    JComboBox fileDetectorsComboBox;
     JLabel errorMsg;
     
     @Override
@@ -67,6 +63,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         	RemoteDriverConfig config = (RemoteDriverConfig) element;
             remoteSeleniumGridText.setText(config.getSeleniumGridUrl());
             capabilitiesComboBox.setSelectedItem(config.getCapability());
+            fileDetectorsComboBox.setSelectedItem(config.getFileDetectorOption());
         }
     }
 
@@ -77,6 +74,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         	RemoteDriverConfig config = (RemoteDriverConfig) element;
             config.setSeleniumGridUrl(remoteSeleniumGridText.getText());
             config.setCapability((RemoteCapability)capabilitiesComboBox.getSelectedItem());
+            config.setFileDetectorOption((FileDetectorOption)fileDetectorsComboBox.getSelectedItem());
         }
     }
 
@@ -85,6 +83,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         final JPanel remotePanel = new VerticalPanel();
         final JLabel remoteUrlLabel = new JLabel();
         final JLabel capabilitiesLabel = new JLabel();
+        final JLabel fileDetectorLabel = new JLabel();
         
         
         remoteUrlLabel.setText("Selenium Grid URL");
@@ -93,13 +92,18 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         remoteSeleniumGridText.addFocusListener(this);
         capabilitiesLabel.setText("Capability");
         capabilitiesComboBox = new JComboBox(RemoteCapability.values());
-        
+
+        fileDetectorLabel.setText("File detector");
+        fileDetectorsComboBox = new JComboBox(FileDetectorOption.values());
+
         remotePanel.add(remoteUrlLabel);
         remotePanel.add(remoteSeleniumGridText);
         remotePanel.add(errorMsg=new JLabel());
         remotePanel.add(capabilitiesLabel);
         remotePanel.add(capabilitiesComboBox);
-        
+        remotePanel.add(fileDetectorLabel);
+        remotePanel.add(fileDetectorsComboBox);
+
         errorMsg.setForeground(Color.red);
         
         browserPanel.add(remotePanel);
@@ -112,6 +116,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui implements ItemLis
         super.clearGui();
         remoteSeleniumGridText.setText(StringUtils.EMPTY);
         capabilitiesComboBox.setSelectedIndex(2);
+        fileDetectorsComboBox.setSelectedIndex(1);
     }
 
 	@Override

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
@@ -28,7 +28,9 @@ import org.mockito.Mockito;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.UselessFileDetector;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -101,11 +103,28 @@ public class RemoteDriverConfigTest {
         assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
         assertThat(capabilities.isJavascriptEnabled(), is(true));
     }
-    
+
     @Test
-	public void should() throws Exception {
-		
-	}
+    public void should() throws Exception {
+
+    }
+
+    @Test
+    public void shouldRevertToDefaultFileLocator() throws Exception {
+        assertEquals(FileDetectorOption.USELESS, config.getFileDetectorOption());
+    }
+
+    @Test
+    public void shouldProduceLocalFileLocator() throws Exception {
+        config.setFileDetectorOption(FileDetectorOption.LOCAL);
+        assertTrue(config.createFileDetector() instanceof LocalFileDetector);
+    }
+
+    @Test
+    public void shouldProduceUselessFileLocator() throws Exception {
+        config.setFileDetectorOption(FileDetectorOption.USELESS);
+        assertTrue(config.createFileDetector() instanceof UselessFileDetector);
+    }
     
     @Test
 	public void shouldThrowAnExceptionWhenTheURLIsMalformed() throws Exception {

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
@@ -110,18 +110,18 @@ public class RemoteDriverConfigTest {
     }
 
     @Test
-    public void shouldRevertToDefaultFileLocator() throws Exception {
+    public void shouldRevertToDefaultFileLocator() {
         assertEquals(FileDetectorOption.USELESS, config.getFileDetectorOption());
     }
 
     @Test
-    public void shouldProduceLocalFileLocator() throws Exception {
+    public void shouldProduceLocalFileLocator() {
         config.setFileDetectorOption(FileDetectorOption.LOCAL);
         assertTrue(config.createFileDetector() instanceof LocalFileDetector);
     }
 
     @Test
-    public void shouldProduceUselessFileLocator() throws Exception {
+    public void shouldProduceUselessFileLocator() {
         config.setFileDetectorOption(FileDetectorOption.USELESS);
         assertTrue(config.createFileDetector() instanceof UselessFileDetector);
     }


### PR DESCRIPTION
We have a requirement to upload files to a site under test via Selenium grid. In order to do this the remote web driver has to have the LocalFileDetector set (instead of the aptly named UselessFileDetector). 

I have added the option to select which file detector is used when creating the remote driver.