### PR TITLE
Modified markerClass

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -411,7 +411,7 @@
     "helpUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener",
     "screenshotUrl": "https://camo.githubusercontent.com/03f25b0b0323f0f42470165187af0ee8b2528428/68747470733a2f2f696d6167652e6962622e636f2f6a57364c4e782f53637265656e5f53686f745f323031385f30335f32315f61745f31305f32315f31385f414d2e706e67",
     "vendor": "Delirius325",
-    "markerClass": "io.github.delirius325.jmeter.backendlistener.elasticsearch.ElasticsearchBackend",
+    "markerClass": "io.github.delirius325.jmeter.backendlistener.elasticsearch.ElasticsearchBackendClient",
     "versions": {
       "2.2.3": {
         "changes": "DEPRECATED. Added back because of an issue with the plugins manager not uninstalling it.",


### PR DESCRIPTION
Fixes an issue where the ElasticSearch Backend Listener is always marked as being available (uninstalled) when it's false.