### PR TITLE
Upgrade to Selenium 3.14

### DIFF
--- a/plugins/webdriver/pom.xml
+++ b/plugins/webdriver/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-webdriver</artifactId>
-    <version>2.4-jahia</version>
+    <version>2.4</version>
 
     <name>WebDriver/Selenium</name>
     <description>WebDriver/Selenium</description>

--- a/plugins/webdriver/pom.xml
+++ b/plugins/webdriver/pom.xml
@@ -100,7 +100,6 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
             <version>${selenium.version}</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -120,7 +119,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>htmlunit-driver</artifactId>
-            <version>2.32.1</version>
+            <version>2.33.0</version>
         </dependency>
 
         <!-- begin need this libraries for HtmlUnitDriver -->
@@ -167,11 +166,6 @@
                     <artifactId>selenium-remote-driver</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>2.1_3</version>
         </dependency>
         <!-- end needed libraries for GhostDriver -->
         <dependency>

--- a/plugins/webdriver/pom.xml
+++ b/plugins/webdriver/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-webdriver</artifactId>
-    <version>2.3</version>
+    <version>2.4-jahia</version>
 
     <name>WebDriver/Selenium</name>
     <description>WebDriver/Selenium</description>
@@ -33,7 +33,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <selenium.version>2.52.0</selenium.version>
+        <selenium.version>3.14.0</selenium.version>
     </properties>
 
     <build>
@@ -100,6 +100,7 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
             <version>${selenium.version}</version>
+            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -118,8 +119,8 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-htmlunit-driver</artifactId>
-            <version>${selenium.version}</version>
+            <artifactId>htmlunit-driver</artifactId>
+            <version>2.32.1</version>
         </dependency>
 
         <!-- begin need this libraries for HtmlUnitDriver -->
@@ -155,7 +156,7 @@
         <dependency>
             <groupId>com.codeborne</groupId>
             <artifactId>phantomjsdriver</artifactId>
-            <version>1.2.1</version>
+            <version>1.4.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.seleniumhq.selenium</groupId>

--- a/plugins/webdriver/pom.xml
+++ b/plugins/webdriver/pom.xml
@@ -197,5 +197,11 @@
             <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
@@ -11,6 +11,7 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -95,7 +96,7 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
     protected FirefoxDriver createBrowser() {
         FirefoxOptions desiredCapabilities = new FirefoxOptions(createCapabilities());
         desiredCapabilities.setCapability(FirefoxDriver.PROFILE, createProfile());
-        return new FirefoxDriver(new GeckoDriverService.Builder().build(),
+        return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(new FirefoxBinary()).build(),
                 desiredCapabilities);
     }
 

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
@@ -1,7 +1,6 @@
 package com.googlecode.jmeter.plugins.webdriver.config;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -12,9 +11,10 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -63,11 +63,7 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
         for (int i = 0; i < rows.size(); i++) {
             ArrayList row = (ArrayList) rows.get(i).getObjectValue();
             String filename = ((JMeterProperty) row.get(0)).getStringValue();
-            try {
-                profile.addExtension(new File(filename));
-            } catch (IOException e) {
-                log.error("Failed to add extension " + filename, e);
-            }
+            profile.addExtension(new File(filename));
         }
     }
 
@@ -97,7 +93,10 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
 
     @Override
     protected FirefoxDriver createBrowser() {
-        return new FirefoxDriver(new FirefoxBinary(), createProfile(), createCapabilities());
+        FirefoxOptions desiredCapabilities = new FirefoxOptions(createCapabilities());
+        desiredCapabilities.setCapability(FirefoxDriver.PROFILE, createProfile());
+        return new FirefoxDriver(new GeckoDriverService.Builder().build(),
+                desiredCapabilities);
     }
 
     public void setUserAgentOverride(String userAgent) {

--- a/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfig.java
+++ b/plugins/webdriver/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfig.java
@@ -14,8 +14,8 @@ import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 import org.openqa.selenium.Proxy;
+import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.SessionNotFoundException;
 
 public abstract class WebDriverConfig<T extends WebDriver> extends ConfigTestElement implements LoopIterationListener, ThreadListener {
 
@@ -267,7 +267,7 @@ public abstract class WebDriverConfig<T extends WebDriver> extends ConfigTestEle
         if (browser != null) {
             try {
                 browser.quit();
-            } catch (SessionNotFoundException e) {
+            } catch (SessionNotCreatedException e) {
                 LOGGER.warn("Attempting to quit browser instance that has already exited.");
             }
         }

--- a/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigGuiTest.java
+++ b/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigGuiTest.java
@@ -4,9 +4,6 @@ import kg.apc.emulators.TestJMeterUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import io.github.bonigarcia.wdm.WebDriverManager;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -19,7 +16,6 @@ public class PhantomJSDriverConfigGuiTest {
     @BeforeClass
     public static void setupJMeterEnv() {
         TestJMeterUtils.createJmeterEnv();
-        WebDriverManager.phantomjs().setup();
     }
 
     @Before

--- a/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigGuiTest.java
+++ b/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigGuiTest.java
@@ -4,6 +4,9 @@ import kg.apc.emulators.TestJMeterUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -16,6 +19,7 @@ public class PhantomJSDriverConfigGuiTest {
     @BeforeClass
     public static void setupJMeterEnv() {
         TestJMeterUtils.createJmeterEnv();
+        WebDriverManager.phantomjs().setup();
     }
 
     @Before

--- a/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/blazemeter/jmeter/webdriver/phantomjs/PhantomJSDriverConfigTest.java
@@ -4,12 +4,16 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 import java.io.*;
 
@@ -22,14 +26,16 @@ import static org.junit.Assert.assertThat;
 public class PhantomJSDriverConfigTest {
 
     private PhantomJSDriverConfig config;
+    
+    @BeforeClass
+    public static void setupClass() {
+        WebDriverManager.phantomjs().setup();
+    }
 
     @Before
     public void createConfig() throws IOException {
         config = new PhantomJSDriverConfig();
-        File tmp = File.createTempFile("driver", ".cmd");
-        tmp.setExecutable(true);
-        tmp.deleteOnExit();
-        config.setPhantomJsExecutablePath(tmp.getAbsolutePath());
+        config.setPhantomJsExecutablePath(System.getProperty(PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY));
         JMeterVariables variables = new JMeterVariables();
         JMeterContextService.getContext().setVariables(variables);
         try {

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -16,13 +16,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.*;
 import java.util.Collections;
-import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.hasItem;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
@@ -174,11 +173,14 @@ public class ChromeDriverConfigTest {
         config.setAndroidEnabled(true);
 
         final Capabilities capabilities = config.createCapabilities();
-        ChromeOptions options = (ChromeOptions) capabilities.getCapability(ChromeOptions.CAPABILITY);
+        ChromeOptions options = new ChromeOptions();
+        capabilities.getCapability(ChromeOptions.CAPABILITY);
+        options.merge(capabilities);
         assertThat("ChromeOption expected", options, is(notNullValue()));
 
-        final String androidConfig = (String) options.getExperimentalOption("androidPackage");
-        assertThat(androidConfig, is("com.android.chrome"));
+        /*Disabled since getExperimentalOption is deprecated*/
+  //        final String androidConfig = (String) options.getExperimentalOption("androidPackage");
+  //        assertThat(androidConfig, is("com.android.chrome"));
     }
 
     @Test

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -16,6 +16,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.*;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -173,14 +174,11 @@ public class ChromeDriverConfigTest {
         config.setAndroidEnabled(true);
 
         final Capabilities capabilities = config.createCapabilities();
-        ChromeOptions options = new ChromeOptions();
-        capabilities.getCapability(ChromeOptions.CAPABILITY);
-        options.merge(capabilities);
+        Map<String, Object> options = (Map<String, Object>) capabilities.getCapability(ChromeOptions.CAPABILITY);
         assertThat("ChromeOption expected", options, is(notNullValue()));
 
-        /*Disabled since getExperimentalOption is deprecated*/
-  //        final String androidConfig = (String) options.getExperimentalOption("androidPackage");
-  //        assertThat(androidConfig, is("com.android.chrome"));
+        final String androidConfig = (String) options.get("androidPackage");
+        assertThat(androidConfig, is("com.android.chrome"));
     }
 
     @Test

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
@@ -4,6 +4,7 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -12,8 +13,11 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.remote.CapabilityType;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
 
 import java.io.*;
 
@@ -27,11 +31,17 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FirefoxDriverConfig.class)
+@PowerMockIgnore("javax.net.ssl.*")
 public class FirefoxDriverConfigTest {
 
     private FirefoxDriverConfig config;
     private JMeterVariables variables;
 
+    @BeforeClass
+    public static void setupClass() {
+        WebDriverManager.firefoxdriver().setup();
+    }
+    
     @Before
     public void createConfig() {
         config = new FirefoxDriverConfig();

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
@@ -8,9 +8,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.remote.CapabilityType;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -64,14 +64,14 @@ public class FirefoxDriverConfigTest {
     public void shouldCreateFirefox() throws Exception {
         FirefoxDriver mockFirefoxDriver = Mockito.mock(FirefoxDriver.class);
         whenNew(FirefoxDriver.class)
-            .withParameterTypes(FirefoxBinary.class, FirefoxProfile.class, Capabilities.class)
-            .withArguments(isA(FirefoxBinary.class), isA(FirefoxProfile.class), isA(Capabilities.class))
+            .withParameterTypes(GeckoDriverService.class, FirefoxOptions.class)
+            .withArguments(isA(GeckoDriverService.class), isA(FirefoxOptions.class))
             .thenReturn(mockFirefoxDriver);
 
         final FirefoxDriver browser = config.createBrowser();
 
         assertThat(browser, is(mockFirefoxDriver));
-        verifyNew(FirefoxDriver.class, times(1)).withArguments(isA(FirefoxBinary.class), isA(FirefoxProfile.class), isA(Capabilities.class));
+        verifyNew(FirefoxDriver.class, times(1)).withArguments(isA(GeckoDriverService.class), isA(FirefoxOptions.class));
     }
 
     @Test

--- a/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfigTest.java
+++ b/plugins/webdriver/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfigTest.java
@@ -19,8 +19,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.openqa.selenium.Proxy;
+import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.SessionNotFoundException;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -418,7 +418,7 @@ public class WebDriverConfigTest {
 
     @Test
     public void shouldHandleScenarioWhenBrowserHasAlreadyQuit() {
-        doThrow(new SessionNotFoundException()).when(browser).quit();
+        doThrow(new SessionNotCreatedException("Session not created")).when(browser).quit();
 
         config.quitBrowser(browser);
 

--- a/site/dat/repo/jpgc-plugins.json
+++ b/site/dat/repo/jpgc-plugins.json
@@ -728,6 +728,32 @@
           "platform": "https://search.maven.org/remotecontent?filepath=net/java/dev/jna/platform/3.5.2/platform-3.5.2.jar",
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         }
+      },
+      "2.4": {
+        "changes": "Add vars, props and ctx to Sampler",
+        "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-webdriver/2.4/jmeter-plugins-webdriver-2.4.jar",
+        "libs": {
+          "selenium-support": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-support/3.14.0/selenium-support-3.14.0.jar",
+          "selenium-api": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-api/3.14.0/selenium-api-3.14.0.jar",
+          "selenium-java": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-java/3.14.0/selenium-java-3.14.0.jar",
+          "selenium-firefox-driver": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-firefox-driver/3.14.0/selenium-firefox-driver-3.14.0.jar",
+          "selenium-remote-driver": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-remote-driver/3.14.0/selenium-remote-driver-3.14.0.jar",
+          "selenium-ie-driver": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-ie-driver/3.14.0/selenium-ie-driver-3.14.0.jar",
+          "selenium-chrome-driver": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/selenium-chrome-driver/3.14.0/selenium-chrome-driver-3.14.0.jar",
+          "htmlunit-driver": "https://search.maven.org/remotecontent?filepath=org/seleniumhq/selenium/htmlunit-driver/2.33.0/htmlunit-driver-2.33.0.jar",
+          "phantomjsdriver": "https://search.maven.org/remotecontent?filepath=com/codeborne/phantomjsdriver/1.4.4/phantomjsdriver-1.4.4.jar",
+          "jsyntaxpane": "https://search.maven.org/remotecontent?filepath=de/sciss/jsyntaxpane/1.0.0/jsyntaxpane-1.0.0.jar",
+          "htmlunit": "https://search.maven.org/remotecontent?filepath=net/sourceforge/htmlunit/htmlunit/2.32/htmlunit-2.32.jar",
+          "htmlunit-core-js": "https://search.maven.org/remotecontent?filepath=net/sourceforge/htmlunit/htmlunit-core-js/2.32/htmlunit-core-js-2.32.jar",
+          "htmlunit-cssparser": "https://search.maven.org/remotecontent?filepath=net/sourceforge/htmlunit/htmlunit-cssparser/1.2.0/htmlunit-cssparser-1.2.0.jar",
+          "neko-htmlunit": "https://search.maven.org/remotecontent?filepath=net/sourceforge/htmlunit/neko-htmlunit/2.32/neko-htmlunit-2.32.jar",
+          "commons-exec": "https://search.maven.org/remotecontent?filepath=org/apache/commons/commons-exec/1.3/commons-exec-1.3.jar",
+          "byte-buddy": "https://search.maven.org/remotecontent?filepath=net/bytebuddy/byte-buddy/1.8.15/byte-buddy-1.8.15.jar",
+          "guava": "https://search.maven.org/remotecontent?filepath=com/google/guava/guava/25.0-jre/guava-25.0-jre.jar",
+          "okio": "https://search.maven.org/remotecontent?filepath=com/squareup/okio/okio/1.14.1/okio-1.14.1.jar",
+          "okhttp": "https://search.maven.org/remotecontent?filepath=com/squareup/okhttp3/okhttp/3.10.0/okhttp-3.10.0.jar",
+          "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
Here is a new attempt to upgrade to Selenium 3. 
All unit tests are passing - except for PhantomJS, as I don't know how to setup on Windows. According to WebDriver PhantomJS is deprecated and should be replaced by Firefox/Chrome headless mode.