### PR TITLE
HLSPlugin v1.3

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -479,6 +479,13 @@
           "jmeter-http"
         ]
       }
+    },
+    "1.3": {
+      "changes": "Plugin name has been changed to continue with the convention of BlazeMeter plugins.\nLogo has been added.\nIssue in live stream when it did not show results in View Results Tree has been fixed.",
+      "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v1.3/jmeter-hls-1.3.jar",
+      "depends": [
+        "jmeter-http"
+      ]
     }
   },
   {


### PR DESCRIPTION
•Logo has been added.

•Plugin name has been changed to continue with the convention of BlazeMeter plugins .

•Issue in live stream when it did not show results in *View Results Tree* has been fixed.