### PR TITLE
Added capability to set Y-Axis label on perfmon charts.

### DIFF
--- a/tools/cmd/src/main/java/kg/apc/cmdtools/ReporterTool.java
+++ b/tools/cmd/src/main/java/kg/apc/cmdtools/ReporterTool.java
@@ -46,6 +46,7 @@ public class ReporterTool extends AbstractCMDTool {
                 + "--exclude-label-regex <true/false> " // filter samples label with regex
                 + "--start-offset <sec>" // filter samples on period time
                 + "--end-offset <sec>" // filter samples on period time
+                + "--yAxisLabel <string>" // Label string for Y-Axis on chart
                 + "]");
     }
 
@@ -247,6 +248,11 @@ public class ReporterTool extends AbstractCMDTool {
                 }
 
                 worker.setEndOffset((String) args.next());
+            } else if (nextArg.equalsIgnoreCase("--yAxisLabel")) {
+                if (!args.hasNext()) {
+                    throw new IllegalArgumentException("Missing Y-Axis label string");
+                }
+                worker.setYAxisLabel((String) args.next());
             } else {
                 worker.processUnknownOption(nextArg, args);
             }

--- a/tools/cmd/src/main/java/kg/apc/jmeter/PluginsCMDWorker.java
+++ b/tools/cmd/src/main/java/kg/apc/jmeter/PluginsCMDWorker.java
@@ -46,6 +46,7 @@ public class PluginsCMDWorker {
     private int excludeSamplesWithRegex = -1;
     private int successFilter = -1;
     private int markers = -1;
+    private String yAxisLabel="Performance Metrics";
 
     public PluginsCMDWorker() {
         log.info("Using JMeterPluginsCMD v. " + JMeterPluginsUtils.getVersion());
@@ -100,6 +101,13 @@ public class PluginsCMDWorker {
         graphHeight = i;
     }
 
+
+    public void setYAxisLabel(String yAxisLabel) {
+        if(yAxisLabel != null) {
+            this.yAxisLabel = yAxisLabel;
+        }
+    }
+
     public int doJob() {
         checkParams();
 
@@ -141,6 +149,8 @@ public class PluginsCMDWorker {
 
         // to handle issue 64 and since it must be cheap - set options again
         setOptions(pluginInstance);
+
+        pluginInstance.getGraphPanelChart().setYAxisLabel(yAxisLabel);
 
         if ((exportMode & EXPORT_PNG) == EXPORT_PNG) {
             File pngFile = new File(outputPNG);

--- a/tools/cmd/src/test/java/kg/apc/cmdtools/ReporterToolTest.java
+++ b/tools/cmd/src/test/java/kg/apc/cmdtools/ReporterToolTest.java
@@ -51,8 +51,9 @@ public class ReporterToolTest {
         File f = File.createTempFile("test", ".csv");
         String str = "--generate-csv " + f.getAbsolutePath() + " "
                 + "--input-jtl " + basedir + "/short.jtl "
-                + "--aggregate-rows yes --plugin-type ResponseTimesOverTime";
+                + "--aggregate-rows yes --plugin-type ResponseTimesOverTime --yAxisLabel 'ResponseTime[ms]'";
         String[] args = str.split(" +");
+
         ReporterTool instance = new ReporterTool();
         int expResult = 0;
         int result = instance.processParams(PluginsCMD.argsArrayToListIterator(args));
@@ -67,6 +68,7 @@ public class ReporterToolTest {
         File f = File.createTempFile("test", ".png");
         String str = "--width 800 --height 600 "
                 + "--plugin-type HitsPerSecond  "
+                + "--yAxisLabel 'Hits/sec'"
                 + "--aggregate-rows yes "
                 + "--generate-png " + f.getAbsolutePath() + " "
                 + "--input-jtl " + basedir + "/short.jtl";

--- a/tools/cmd/src/test/java/kg/apc/jmeter/PluginsCMDWorkerTest.java
+++ b/tools/cmd/src/test/java/kg/apc/jmeter/PluginsCMDWorkerTest.java
@@ -160,6 +160,16 @@ public class PluginsCMDWorkerTest {
         instance.setGraphHeight(i);
     }
 
+    /**
+     * Test of setYAxisLabel method, of class PluginsCMDWorker.
+     */
+    @Test
+    public void testSetYAxisLabel() {
+        System.out.println("setYAxisLabel");
+        String newYAxisLabel = "Response time [ms]";
+        instance.setYAxisLabel(newYAxisLabel);
+    }
+
     @Test
     public void testSetAggregate() {
         System.out.println("setAggregate");

--- a/tools/cmd/src/test/java/kg/apc/jmeter/PluginsCMDWorkerTest.java
+++ b/tools/cmd/src/test/java/kg/apc/jmeter/PluginsCMDWorkerTest.java
@@ -72,6 +72,7 @@ public class PluginsCMDWorkerTest {
         instance.setInputFile(basedir + "/short.jtl");
         File pngfile = File.createTempFile("test", ".png");
         instance.setOutputPNGFile(pngfile.getAbsolutePath());
+        instance.setYAxisLabel("Response time [ms]");
         File csvfile = File.createTempFile("test", ".csv");
         instance.setOutputCSVFile(csvfile.getAbsolutePath());
         instance.setPluginType("ResponseTimesOverTime");
@@ -91,6 +92,7 @@ public class PluginsCMDWorkerTest {
         System.out.println("doJob 2");
         instance.setInputFile(basedir + "/short.jtl");
         instance.setOutputPNGFile(File.createTempFile("test", ".png").getAbsolutePath());
+        instance.setYAxisLabel("Response time [ms]");
         instance.setPluginType("ResponseTimesOverTime");
         instance.addExportMode(PluginsCMDWorker.EXPORT_PNG);
         int result = instance.doJob();


### PR DESCRIPTION
Having possibility to label Y-Axis in performance tests tool making charts is a must. 

Otherwise each time report is sent, people are asking what are units on Y axis? Its According to my own experience with perf tests and this:

https://groups.google.com/forum/#!topic/jmeter-plugins/zjTwY38X_z8
https://groups.google.com/forum/#!searchin/jmeter-plugins/axis|sort:date/jmeter-plugins/C-mQuB_8PI8/Bdc6pNlyxNYJ
https://groups.google.com/forum/#!searchin/jmeter-plugins/axis|sort:date/jmeter-plugins/zjTwY38X_z8/s8pbcK-tmk8J


So I've added posibility to set Y-label using `--yAxisLabel <String>` option. If its not specified default String which is "Performance Metrics" like currently is used, so it shouldn't be breaking anything.

I made this change way to not disrupt other things, so if no --yAxisLabel is specified, it uses default value, which is "Performance Metrics" like now, otherwise this label is set.