### PR TITLE
Fix Maven download filenames

### DIFF
--- a/downloads.py
+++ b/downloads.py
@@ -60,7 +60,8 @@ def download_into_dir(dirname, url, dest_subpath):
     resp = requests.get(url)
     assert resp.status_code == 200
     if 'content-disposition' in resp.headers:
-        remote_filename = re.findall("filename=(.+)", resp.headers['content-disposition'])[0]
+        # handle optional quotes around filename:
+        remote_filename = re.sub('.*filename=(")?(?P<filename>.+)(?(1)"|$).*', "\g<filename>", resp.headers['content-disposition'])
     else:
         remote_filename = os.path.basename(resp.url)
 
@@ -97,7 +98,7 @@ if __name__ == "__main__":
     for repo_file in os.listdir(repo_dir):
         with open(os.path.join(repo_dir, repo_file)) as fhd:
             content = json.loads(fhd.read())
-            jsonschema.validate(content, schema)
+#            jsonschema.validate(content, schema)
             plugins.extend(content)
 
     if len(sys.argv) > 1:

--- a/downloads.py
+++ b/downloads.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     for repo_file in os.listdir(repo_dir):
         with open(os.path.join(repo_dir, repo_file)) as fhd:
             content = json.loads(fhd.read())
-#            jsonschema.validate(content, schema)
+            jsonschema.validate(content, schema)
             plugins.extend(content)
 
     if len(sys.argv) > 1:


### PR DESCRIPTION
Handle optional quotes around filename when downloading Maven libs.
See https://groups.google.com/forum/#!topic/jmeter-plugins/wJDHJkoc98o