### PR TITLE
Register UbikLoadPack Autocorrelator plugin on jmeter-plugins

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -597,5 +597,26 @@
         ]
       }
     }
+  },
+  {
+    "id": "ulp-jmeter-autocorrelator-plugin",
+    "name": "UbikLoadPack Auto-correlator plugin",
+    "description": "Plugin which provides the ability to easily load tests Vaadin, Oracle Siebel, Oracle PeopleSoft, Oracle Hyperion and Oracle JD-Edwards applications with Apache JMeter",
+    "screenshotUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-autocorrelator-plugin/ulp_ac_presentationScreenshot.png",
+    "helpUrl": "https://www.ubik-ingenierie.com/blog/ubikloadpack-autocorrelator-plugin-help/",
+    "vendor": "UbikLoadPack by Ubik-Ingenierie",
+    "markerClass": "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPreProcessor",
+    "componentClasses": [
+      "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPostProcessor",
+      "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPostProcessorGui",
+      "com.ubikingenierie.jmeter.plugin.autocorrelator.prepro.AutoCorrelatorPreProcessor",
+      "com.ubikingenierie.jmeter.plugin.autocorrelator.prepro.AutoCorrelatorPreProcessorGui"
+    ],
+    "versions": {
+      "4.2.0": {
+        "downloadUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-autocorrelator-plugin/4.2.0/ubik-jmeter-autocorrelator-plugin-4.2.0.jar",
+        "depends":["jmeter-core", "jmeter-components", "jmeter-http"]
+      }
+    }
   }
 ]


### PR DESCRIPTION
Hello @undera ,

This PR is to register our UbikLoadPack Autocorrelator plugin so that it's available through jmeter-plugins-manager.
We think we have provided required elements, but let us know if anything is missing.

Kudos to all your OSS work for the JMeter community.

Thanks
Regards