### PR TITLE
Fix markerClass for UbikLoadPack Autocorrelator Plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -605,7 +605,7 @@
     "screenshotUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-autocorrelator-plugin/ulp_ac_presentationScreenshot.png",
     "helpUrl": "https://www.ubik-ingenierie.com/blog/ubikloadpack-autocorrelator-plugin-help/",
     "vendor": "UbikLoadPack by Ubik-Ingenierie",
-    "markerClass": "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPreProcessor",
+    "markerClass": "com.ubikingenierie.jmeter.plugin.autocorrelator.prepro.AutoCorrelatorPreProcessor",
     "componentClasses": [
       "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPostProcessor",
       "com.ubikingenierie.jmeter.plugin.autocorrelator.postpro.AutoCorrelatorPostProcessorGui",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -601,7 +601,7 @@
   {
     "id": "ulp-jmeter-autocorrelator-plugin",
     "name": "UbikLoadPack Auto-correlator plugin",
-    "description": "Plugin which provides the ability to easily load tests Vaadin, Oracle Siebel, Oracle PeopleSoft, Oracle Hyperion and Oracle JD-Edwards applications with Apache JMeter",
+    "description": "Plugin which provides the ability to easily load tests Vaadin, Oracle Siebel, Oracle PeopleSoft, Oracle Hyperion and Oracle JD-Edwards EntrepriseOne (JDE Eone) applications with Apache JMeter",
     "screenshotUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-autocorrelator-plugin/ulp_ac_presentationScreenshot.png",
     "helpUrl": "https://www.ubik-ingenierie.com/blog/ubikloadpack-autocorrelator-plugin-help/",
     "vendor": "UbikLoadPack by Ubik-Ingenierie",


### PR DESCRIPTION
Hello @undera ,
There was a typo in PR 357 on markerClass which leads Plugins manager to think plugin is not installed.

This PR fixes the issue.
Thank you for merging last one rapidly.

Regards