### PR TITLE
RTE-Plugin: Tabulator input support.

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -640,31 +640,39 @@
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/jmeter-bzm-rte-1.0.4.jar",
         "libs": {
           "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/xtn5250-2.0.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/dm3270-lib-0.6.jar"
+          "dm3270-lib>=0.6": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/dm3270-lib-0.6.jar"
         }
       },
       "1.1": {
         "changes": "Support for setting fields by label and update dm3270 which includes tn3270 protocol enhancements support improvements (SSCP LU DATA, BID) and additional fixes (hiding invisible fields from screen and sending some fields back to server)",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/jmeter-bzm-rte-1.1.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/xtn5250-2.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/dm3270-lib-0.7.jar"
+          "xtn5250>=2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/xtn5250-2.1.jar",
+          "dm3270-lib>=0.7": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/dm3270-lib-0.7.jar"
         }
       },
       "1.1.1": {
         "changes": "This version fixes property naming for inputs by label feature",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/jmeter-bzm-rte-1.1.1.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/xtn5250-2.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/dm3270-lib-0.7.jar"
+          "xtn5250>=2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/xtn5250-2.1.jar",
+          "dm3270-lib>=0.7": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/dm3270-lib-0.7.jar"
         }
       },
       "2.0": {
         "changes": "New rte recorder test element added and a many fixes!",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/jmeter-bzm-rte-2.0.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/xtn5250-3.0.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/dm3270-lib-0.10.jar"
+          "xtn5250>=3.0": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/xtn5250-3.0.jar",
+          "dm3270-lib>=0.10": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/dm3270-lib-0.10.jar"
+        }
+      },
+      "2.1": {
+        "changes": "New recorder features allowing to record input by label, wait for text and assertions",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/jmeter-bzm-rte-2.1.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/dm3270-lib-0.11.jar"
         }
       }
     }

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -469,9 +469,6 @@
       },
       "1.1": {
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.1/jmeter-hls-1.1.jar",
-        "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
-        },
         "depends": [
           "jmeter-http"
         ]
@@ -479,9 +476,6 @@
       "1.2": {
         "changes": "Some bugs fixed",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.2/jmeter-hls-1.2.jar",
-        "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
-        },
         "depends": [
           "jmeter-http"
         ]
@@ -489,8 +483,15 @@
       "1.3": {
         "changes": "Plugin name has been changed to continue with the convention of BlazeMeter plugins.\nLogo has been added.\nIssue in live stream when it did not show results in View Results Tree has been fixed.",
         "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v1.3/jmeter-hls-1.3.jar",
+        "depends": [
+          "jmeter-http"
+        ]
+      },
+      "2.0": {
+        "changes": "Major new release with a lot of bug fixes and new features (simplified UI, granular assertions, etc). Please check the readme",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v2.0/jmeter-bzm-hls-2.0.jar",
         "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
+          "hlsparserj>=1.0.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v2.0/hlsparserj-1.0.0.jar"
         },
         "depends": [
           "jmeter-http"

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -710,6 +710,14 @@
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/xtn5250-3.1.jar",
           "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/dm3270-lib-0.11.1.jar"
         }
+      },
+      "2.2.1": {
+        "changes": "Wait conditions behaviour changed and some reported issues fixed",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2.1/jmeter-bzm-rte-2.2.1.jar",
+        "libs": {
+          "xtn5250>=3.2": "https://github.com/Blazemeter/xtn5250/releases/download/v3.2/xtn5250-3.2.jar",
+          "dm3270-lib>=0.12.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.12.1-lib/dm3270-lib-0.12.1.jar"
+        }
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -452,7 +452,7 @@
     "id": "bzm-hls",
     "name": "HLS Sampler",
     "description": "HLS protocol sampler, enabling testing for streaming applications",
-    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/HLSPlugin/master/docs/HLSPluginView.png",
+    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/HLSPlugin/master/docs/sampler.png",
     "helpUrl": "https://github.com/Blazemeter/HLSPlugin/blob/master/README.md",
     "vendor": "BlazeMeter",
     "markerClass": "com.blazemeter.jmeter.hls.logic.HlsSampler",

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -674,6 +674,14 @@
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
           "dm3270-lib>=0.11": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/dm3270-lib-0.11.jar"
         }
+      },
+      "2.1.1": {
+        "changes": "Fix bug originated in version 2.0 which could not allow user to insert empty inputs.",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1.1/jmeter-bzm-rte-2.1.1.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.11.1-lib/dm3270-lib-0.11.1.jar"
+        }
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -586,21 +586,38 @@
           "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
         }
       },
-      "1.4": {
-        "changes": "Fixed serialization issue for JMeter distributed mode",
-        "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.4/jmeter-bzm-http2-1.4.jar",
+        "1.4": {
+          "changes": "Fixed serialization issue for JMeter distributed mode",
+          "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.4/jmeter-bzm-http2-1.4.jar",
+          "depends": [
+            "jmeter-http"
+          ],
+          "libs": {
+            "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
+            "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
+            "http2-hpack>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-hpack/9.4.9.v20180320/http2-hpack-9.4.9.v20180320.jar",
+            "jetty-alpn-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-client/9.4.9.v20180320/jetty-alpn-client-9.4.9.v20180320.jar",
+            "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-openjdk8-client/9.4.9.v20180320/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
+            "jetty-http>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-http/9.4.9.v20180320/jetty-http-9.4.9.v20180320.jar",
+            "jetty-io>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-io/9.4.9.v20180320/jetty-io-9.4.9.v20180320.jar",
+            "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
+          }
+        },
+      "1.4.1": {
+        "changes": "Fix issue handling http responses without body (like 204 status code)",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jmeter-bzm-http2-1.4.1.jar",
         "depends": [
           "jmeter-http"
         ],
         "libs": {
-          "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
-          "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
-          "http2-hpack>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-hpack/9.4.9.v20180320/http2-hpack-9.4.9.v20180320.jar",
-          "jetty-alpn-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-client/9.4.9.v20180320/jetty-alpn-client-9.4.9.v20180320.jar",
-          "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-openjdk8-client/9.4.9.v20180320/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
-          "jetty-http>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-http/9.4.9.v20180320/jetty-http-9.4.9.v20180320.jar",
-          "jetty-io>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-io/9.4.9.v20180320/jetty-io-9.4.9.v20180320.jar",
-          "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
+          "http2-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-client-9.4.9.v20180320.jar",
+          "http2-common>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-common-9.4.9.v20180320.jar",
+          "http2-hpack>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-hpack-9.4.9.v20180320.jar",
+          "jetty-alpn-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-alpn-client-9.4.9.v20180320.jar",
+          "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
+          "jetty-http>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-http-9.4.9.v20180320.jar",
+          "jetty-io>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-io-9.4.9.v20180320.jar",
+          "jetty-util>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-util-9.4.9.v20180320.jar"
         }
       }
     }
@@ -681,6 +698,14 @@
         "libs": {
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
           "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.11.1-lib/dm3270-lib-0.11.1.jar"
+        }
+      },
+      "2.2": {
+        "changes": "Extractor post-processor added, hide credentials and sampler naming while recording!",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/jmeter-bzm-rte-2.2.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/dm3270-lib-0.11.1.jar"
         }
       }
     }

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -556,6 +556,10 @@
       "2.6.8": {
         "changes": "Fixed breaking issue with SSL conflicts",
         "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.6.8/jmeter.backendlistener.elasticsearch-2.6.8.jar"
+      },
+      "2.6.9": {
+        "changes": "Fixed breaking issue with SSL conflicts",
+        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.6.9/jmeter.backendlistener.elasticsearch-2.6.9.jar"
       }
     }
   },


### PR DESCRIPTION
- Tabulator input support.
    - Now you can create a new type of input called Tabulator Input, which will allow you instead of defining the coordinates, as usual, to send a value with differents amount of tabs before the input.