### PR TITLE
Added Patch 3.0.1 for HLS plugin

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -514,6 +514,24 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.0.1": {
+        "changes": "Patch fix for playlist reload timing and behaviour for interrupted tests",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jmeter-bzm-hls-3.0.1.jar",
+        "libs": {
+          "hlsparserj>=1.0.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/hlsparserj-1.0.0.jar",
+          "mpd-parser>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/mpd-parser-0.8-jdk8.jar",
+          "jackson-core>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jackson-core-2.10.2.jar",
+          "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jackson-dataformat-xml-2.10.2.jar",
+          "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jackson-annotations-2.10.2.jar",
+          "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jackson-databind-2.10.2.jar",
+          "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/jackson-module-jaxb-annotations-2.10.2.jar",
+          "stax2-api>=4.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/stax2-api-4.2.jar",
+          "woodstox-core>=5.3.0":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0.1/woodstox-core-5.3.0.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -640,31 +640,39 @@
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/jmeter-bzm-rte-1.0.4.jar",
         "libs": {
           "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/xtn5250-2.0.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/dm3270-lib-0.6.jar"
+          "dm3270-lib>=0.6": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.0.4/dm3270-lib-0.6.jar"
         }
       },
       "1.1": {
         "changes": "Support for setting fields by label and update dm3270 which includes tn3270 protocol enhancements support improvements (SSCP LU DATA, BID) and additional fixes (hiding invisible fields from screen and sending some fields back to server)",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/jmeter-bzm-rte-1.1.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/xtn5250-2.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/dm3270-lib-0.7.jar"
+          "xtn5250>=2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/xtn5250-2.1.jar",
+          "dm3270-lib>=0.7": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1/dm3270-lib-0.7.jar"
         }
       },
       "1.1.1": {
         "changes": "This version fixes property naming for inputs by label feature",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/jmeter-bzm-rte-1.1.1.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/xtn5250-2.1.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/dm3270-lib-0.7.jar"
+          "xtn5250>=2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/xtn5250-2.1.jar",
+          "dm3270-lib>=0.7": "https://github.com/Blazemeter/RTEPlugin/releases/download/v1.1.1/dm3270-lib-0.7.jar"
         }
       },
       "2.0": {
         "changes": "New rte recorder test element added and a many fixes!",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/jmeter-bzm-rte-2.0.jar",
         "libs": {
-          "xtn5250": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/xtn5250-3.0.jar",
-          "dm3270-lib": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/dm3270-lib-0.10.jar"
+          "xtn5250>=3.0": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/xtn5250-3.0.jar",
+          "dm3270-lib>=0.10": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.0/dm3270-lib-0.10.jar"
+        }
+      },
+      "2.1": {
+        "changes": "New recorder features allowing to record input by label, wait for text and assertions",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/jmeter-bzm-rte-2.1.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/dm3270-lib-0.11.jar"
         }
       }
     }

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -469,9 +469,6 @@
       },
       "1.1": {
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.1/jmeter-hls-1.1.jar",
-        "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
-        },
         "depends": [
           "jmeter-http"
         ]
@@ -479,9 +476,6 @@
       "1.2": {
         "changes": "Some bugs fixed",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.2/jmeter-hls-1.2.jar",
-        "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
-        },
         "depends": [
           "jmeter-http"
         ]
@@ -489,8 +483,15 @@
       "1.3": {
         "changes": "Plugin name has been changed to continue with the convention of BlazeMeter plugins.\nLogo has been added.\nIssue in live stream when it did not show results in View Results Tree has been fixed.",
         "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v1.3/jmeter-hls-1.3.jar",
+        "depends": [
+          "jmeter-http"
+        ]
+      },
+      "2.0": {
+        "changes": "Major new release with a lot of bug fixes and new features (simplified UI, granular assertions, etc). Please check the readme",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v2.0/jmeter-bzm-hls-2.0.jar",
         "libs": {
-          "mqtt-websocket-java": "https://github.com/inventit/mqtt-websocket-java/releases/download/1.0.1/mqtt-websocket-java-1.0.1.jar"
+          "hlsparserj>=1.0.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v2.0/hlsparserj-1.0.0.jar"
         },
         "depends": [
           "jmeter-http"

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -710,6 +710,14 @@
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/xtn5250-3.1.jar",
           "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/dm3270-lib-0.11.1.jar"
         }
+      },
+      "2.2.1": {
+        "changes": "Wait conditions behaviour changed and some reported issues fixed",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2.1/jmeter-bzm-rte-2.2.1.jar",
+        "libs": {
+          "xtn5250>=3.2": "https://github.com/Blazemeter/xtn5250/releases/download/v3.2/xtn5250-3.2.jar",
+          "dm3270-lib>=0.12.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.12.1-lib/dm3270-lib-0.12.1.jar"
+        }
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -452,7 +452,7 @@
     "id": "bzm-hls",
     "name": "HLS Sampler",
     "description": "HLS protocol sampler, enabling testing for streaming applications",
-    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/HLSPlugin/master/docs/HLSPluginView.png",
+    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/HLSPlugin/master/docs/sampler.png",
     "helpUrl": "https://github.com/Blazemeter/HLSPlugin/blob/master/README.md",
     "vendor": "BlazeMeter",
     "markerClass": "com.blazemeter.jmeter.hls.logic.HlsSampler",

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -674,6 +674,14 @@
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
           "dm3270-lib>=0.11": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/dm3270-lib-0.11.jar"
         }
+      },
+      "2.1.1": {
+        "changes": "Fix bug originated in version 2.0 which could not allow user to insert empty inputs.",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1.1/jmeter-bzm-rte-2.1.1.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.11.1-lib/dm3270-lib-0.11.1.jar"
+        }
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -586,21 +586,38 @@
           "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
         }
       },
-      "1.4": {
-        "changes": "Fixed serialization issue for JMeter distributed mode",
-        "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.4/jmeter-bzm-http2-1.4.jar",
+        "1.4": {
+          "changes": "Fixed serialization issue for JMeter distributed mode",
+          "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.4/jmeter-bzm-http2-1.4.jar",
+          "depends": [
+            "jmeter-http"
+          ],
+          "libs": {
+            "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
+            "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
+            "http2-hpack>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-hpack/9.4.9.v20180320/http2-hpack-9.4.9.v20180320.jar",
+            "jetty-alpn-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-client/9.4.9.v20180320/jetty-alpn-client-9.4.9.v20180320.jar",
+            "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-openjdk8-client/9.4.9.v20180320/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
+            "jetty-http>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-http/9.4.9.v20180320/jetty-http-9.4.9.v20180320.jar",
+            "jetty-io>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-io/9.4.9.v20180320/jetty-io-9.4.9.v20180320.jar",
+            "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
+          }
+        },
+      "1.4.1": {
+        "changes": "Fix issue handling http responses without body (like 204 status code)",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jmeter-bzm-http2-1.4.1.jar",
         "depends": [
           "jmeter-http"
         ],
         "libs": {
-          "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
-          "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
-          "http2-hpack>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-hpack/9.4.9.v20180320/http2-hpack-9.4.9.v20180320.jar",
-          "jetty-alpn-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-client/9.4.9.v20180320/jetty-alpn-client-9.4.9.v20180320.jar",
-          "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-alpn-openjdk8-client/9.4.9.v20180320/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
-          "jetty-http>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-http/9.4.9.v20180320/jetty-http-9.4.9.v20180320.jar",
-          "jetty-io>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-io/9.4.9.v20180320/jetty-io-9.4.9.v20180320.jar",
-          "jetty-util>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-util/9.4.9.v20180320/jetty-util-9.4.9.v20180320.jar"
+          "http2-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-client-9.4.9.v20180320.jar",
+          "http2-common>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-common-9.4.9.v20180320.jar",
+          "http2-hpack>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-hpack-9.4.9.v20180320.jar",
+          "jetty-alpn-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-alpn-client-9.4.9.v20180320.jar",
+          "jetty-alpn-openjdk8-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-alpn-openjdk8-client-9.4.9.v20180320.jar",
+          "jetty-http>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-http-9.4.9.v20180320.jar",
+          "jetty-io>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-io-9.4.9.v20180320.jar",
+          "jetty-util>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jetty-util-9.4.9.v20180320.jar"
         }
       }
     }
@@ -681,6 +698,14 @@
         "libs": {
           "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.1/xtn5250-3.1.jar",
           "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/dm3270/releases/download/v0.11.1-lib/dm3270-lib-0.11.1.jar"
+        }
+      },
+      "2.2": {
+        "changes": "Extractor post-processor added, hide credentials and sampler naming while recording!",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/jmeter-bzm-rte-2.2.jar",
+        "libs": {
+          "xtn5250>=3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/xtn5250-3.1.jar",
+          "dm3270-lib>=0.11.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v2.2/dm3270-lib-0.11.1.jar"
         }
       }
     }

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -556,6 +556,10 @@
       "2.6.8": {
         "changes": "Fixed breaking issue with SSL conflicts",
         "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.6.8/jmeter.backendlistener.elasticsearch-2.6.8.jar"
+      },
+      "2.6.9": {
+        "changes": "Fixed breaking issue with SSL conflicts",
+        "downloadUrl": "https://github.com/delirius325/jmeter-elasticsearch-backend-listener/releases/download/2.6.9/jmeter.backendlistener.elasticsearch-2.6.9.jar"
       }
     }
   },

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -627,7 +627,7 @@
     "id": "ulp-jmeter-videostreaming-plugin",
     "name": "UbikLoadPack Video Streaming plugin",
     "description": "Plugin which provides the ability to easily load test servers delivering Adaptive Bitrate Streaming (ABR). It supports the following implementations: Mpeg-Dash, Apple HLS, Microsoft Smooth (HSS) and Adobe HDS. Both Live and VOD streams are automatically handled. The plugin realistically simulates players and outputs video specific metrics allowing you to analyze User Experience",
-    "screenshotUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-streaming-plugin/ulp_vs_presentationScreenshot.png",
+    "screenshotUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-streaming-plugin/ulp_vs_screenshot_660.png",
     "helpUrl": "https://www.ubik-ingenierie.com/blog/ubikloadpack-streaming-plugin-help/",
     "vendor": "UbikLoadPack by Ubik-Ingenierie",
     "markerClass": "com.ubikingenierie.jmeter.plugin.hls.sampler.HLSSampler",
@@ -636,6 +636,11 @@
       "com.ubikingenierie.jmeter.plugin.hls.gui.HLSSamplerGUI"
     ],
     "versions": {
+    "6.6.0": {
+        "changes": "Let user choose the audio and subtitles track by the language/name of the track, handle EXT-X-MEDIA, handle subtitles, improve HTTPS performances, bugfixes",
+        "downloadUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-streaming-plugin/6.6.0/ubik-jmeter-videostreaming-plugin-6.6.0.jar",
+        "depends":["jmeter-core", "jmeter-components", "jmeter-http"]
+      },
       "6.5.0": {
         "downloadUrl": "https://ubikloadpack.com/plugins/ulp-jmeter-streaming-plugin/6.5.0/ubik-jmeter-videostreaming-plugin-6.5.0.jar",
         "depends":["jmeter-core", "jmeter-components", "jmeter-http"]
@@ -651,6 +656,13 @@
     "vendor": "adrianmo",
     "markerClass": "io.github.adrianmo.jmeter.backendlistener.azure.AzureBackendClient",
     "versions": {
+      "0.2.1": {
+        "changes": "Bug fix release.",
+        "downloadUrl": "https://github.com/adrianmo/jmeter-backend-azure/releases/download/0.2.1/jmeter.backendlistener.azure-0.2.1.jar",
+        "depends": [
+          "jmeter-core"
+        ]
+      },
       "0.2.0": {
         "changes": "Support real-time metrics visualization.",
         "downloadUrl": "https://github.com/adrianmo/jmeter-backend-azure/releases/download/0.2.0/jmeter.backendlistener.azure-0.2.0.jar",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -330,6 +330,18 @@
           "wss4j-ws-security-common>=2.2": "https://search.maven.org/remotecontent?filepath=org/apache/wss4j/wss4j-ws-security-common/2.2.2/wss4j-ws-security-common-2.2.2.jar",
           "xmlsec>=2.1": "https://search.maven.org/remotecontent?filepath=org/apache/santuario/xmlsec/2.1.2/xmlsec-2.1.2.jar"
         }
+      },
+      "1.7": {
+        "changes": "<ul><li>SOAP Message Signer: Support for symmetric signature (HMAC)</li><li>SOAP Message Decrypter: Support for multiple decryption keys</li><li>Default keystore type is now JCEKS (compatible with JKS and PKCS12)</li><li>Bug fixes</li><li>Incompatible changes:</li><ul><li>SOAP Message Decrypter: Private Key Password field removed (use Credentials table instead)</li></ul></ul>",
+        "downloadUrl": "https://github.com/tilln/jmeter-wssecurity/releases/download/1.7/jmeter-wssecurity-1.7.jar",
+        "depends": [
+          "jmeter-core"
+        ],
+        "libs": {
+          "wss4j-ws-security-dom": "https://search.maven.org/remotecontent?filepath=org/apache/wss4j/wss4j-ws-security-dom/2.2.2/wss4j-ws-security-dom-2.2.2.jar",
+          "wss4j-ws-security-common": "https://search.maven.org/remotecontent?filepath=org/apache/wss4j/wss4j-ws-security-common/2.2.2/wss4j-ws-security-common-2.2.2.jar",
+          "xmlsec": "https://search.maven.org/remotecontent?filepath=org/apache/santuario/xmlsec/2.1.2/xmlsec-2.1.2.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
With this PR we are adding the following fixes:
- Fixed the playlist reload to keep working after interrupting a test and starting a new one.
- Fixed rounding issue when calculating reload time to allow for finer reload times.
- We included a jenv file to fix the java version to be used in dev environments using jenv.