### PR TITLE
JMXMon - Add local JMeter connection option

### DIFF
--- a/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPool.java
+++ b/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPool.java
@@ -1,6 +1,7 @@
 package kg.apc.jmeter.jmxmon;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -133,6 +134,12 @@ public class JMXMonConnectionPool {
 			this.jmxUrl = jmxUrl;
 		}
 		
+		/**
+		 * Empty URL denotes local connection
+		 */
+		private boolean isLocalConnection() {
+			return jmxUrl.isEmpty();
+		}
 		
 		/**
 		 * Start a connection thread if none are running
@@ -141,6 +148,11 @@ public class JMXMonConnectionPool {
 		 */
 		protected synchronized void tryConnect(final Hashtable attributes, boolean wait)
 		{
+			if (isLocalConnection()) {
+				log.debug("Using local PlatformMBeanServer connection");
+				connection = ManagementFactory.getPlatformMBeanServer();
+				return;
+			}
 			connectionAttemptFlag = true;
 			
 			connectionAttemptThread = new Thread(new Runnable() {
@@ -186,7 +198,7 @@ public class JMXMonConnectionPool {
 		protected MBeanServerConnection connect(Hashtable attributes, boolean wait) {
 
 			if (connection != null){
-				log.debug("Reused the same connection for url = " + jmxUrl);
+				log.debug("Reused the same connection for url = " + (isLocalConnection()?"(local JVM)":jmxUrl));
 				return connection;
 			}
 			

--- a/plugins/jmxmon/src/test/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPoolTest.java
+++ b/plugins/jmxmon/src/test/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPoolTest.java
@@ -21,7 +21,7 @@ public class JMXMonConnectionPoolTest {
 	private static String jmxUrlOk2 = "service:jmx:rmi:///jndi/rmi://xxxxx:9999/jmxrmi";
 	private static String jmxUrlOk3 = "service:jmx:rmi:///jndi/rmi://yyyyyy:9999/jmxrmi";
 	private static String jmxUrlOk4 = "service:jmx:rmi:///jndi/rmi://zzzzz:9999/jmxrmi";
-	
+	private static String jmxUrlLocal = "";
 	private static String jmxUrlKo = "servicjmxrmi";
 	@BeforeClass
     public static void setUpClass() {
@@ -83,6 +83,18 @@ public class JMXMonConnectionPoolTest {
 		// default test
 		testSubject = createTestSubject();
 		result = testSubject.getConnection(jmxUrlOk, attributes, false);
+	}
+
+	@Test
+	public void testGetConnection_Local() throws Exception {
+		JMXMonConnectionPool testSubject;
+		Hashtable attributes = null;
+		MBeanServerConnection result;
+
+		// default test
+		testSubject = createTestSubject();
+		result = testSubject.getConnection(jmxUrlLocal, attributes);
+		assertNotNull(result);
 	}
 
 	@Test

--- a/site/dat/wiki/JMXMon.wiki
+++ b/site/dat/wiki/JMXMon.wiki
@@ -14,9 +14,9 @@ Just add a "JMXMon Samples Collector" listener where appropriate.
 
 Here are some typical values you might want to use:
 
-URI: service:jmx:rmi:///jndi/rmi://YOURHOST:6969/jmxrmi
+URI: {{{service:jmx:rmi:///jndi/rmi://YOURHOST:6969/jmxrmi}}}
 or
-service:jmx:rmi://YOURHOST:JMX_PORT/jndi/rmi://YOURHOST:JMX_PORT/jmxrmi
+{{{service:jmx:rmi://YOURHOST:JMX_PORT/jndi/rmi://YOURHOST:JMX_PORT/jmxrmi}}}
 
 This field can contains jmeter variables that will be expanded for each call over time if canRetry is checked
 Why? if a server spawn external process, it can return ip and port for jmx connection. It's up to you to extract those values into variable(s) and use then in URI field
@@ -30,6 +30,8 @@ Key (for composite JMX values): used
 Retry : When checked, new connections are attempted during the test and lost connections can be recovered
 
 To change how often the a sample should be taken set the parameter "jmeterPlugin.jmxmon.interval" to the interval in milliseconds, default is every second.
+
+The URL field can be left empty to connect to and monitor the currently running JMeter JVM.
 
 ==Find attributs informations with JConsole==
 Launch the JConsole tool (in the JDK /bin directory)


### PR DESCRIPTION
We almost always include a JMXMon listener in a test plan to monitor the JMeter JVM itself, to make sure there are no long garbage collection pauses or leaks etc.

Connecting JMXMon to the local JMeter JVM requires it to be started with Remote JMX enabled and a TCP port assigned, which can be problematic and is quite unnecessary.

This PR introduces the option to connect to the local JVM's MBeanServer.
This can be configured by specifying a special URL: an empty string.