### PR TITLE
RTE-Plugin v3.0.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -806,6 +806,15 @@
           "dm3270-lib>=0.12.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0/dm3270-lib-0.12.3.jar",
           "jVT220>=1.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0/jVT220-1.3.jar"
         }
+      },
+      "3.0.1": {
+        "changes": "Fix issue with no screen interaction after sample naming",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/jmeter-bzm-rte-3.0.1.jar",
+        "libs": {
+          "xtn5250>=3.2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/xtn5250-3.2.1.jar",
+          "dm3270-lib>=0.12.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/dm3270-lib-0.12.3.jar",
+          "jVT220>=1.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/jVT220-1.3.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
In this patch release, we fixed an issue that was causing no emulator interaction after setting the sample name while recording on VT protocol.