### PR TITLE
Add Jmeter Prometheus plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -814,5 +814,21 @@
         ]
       }
     }
+  },
+    {
+    "id": "jmeter-prometheus",
+    "name": "Prometheus Listener Plugin",
+    "description": "A Jmeter plugin to expose sampled metrics to an endpoint to be scraped by Prometheus.",
+    "screenshotUrl": "https://raw.githubusercontent.com/johrstrom/jmeter-prometheus-plugin/master/docs/imgs/simple_testplan.png",
+    "helpUrl": "https://github.com/johrstrom/jmeter-prometheus-plugin",
+    "vendor": "",
+    "versions": {
+      "0.6.0": {
+        "downloadUrl": "https://github.com/johrstrom/jmeter-prometheus-plugin/releases/download/0.6.0/jmeter-prometheus-plugin-0.6.0.jar",
+        "depends": [
+          "jmeter-core"
+        ]
+      }
+    }
   }
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -821,7 +821,11 @@
     "description": "A Jmeter plugin to expose sampled metrics to an endpoint to be scraped by Prometheus.",
     "screenshotUrl": "https://raw.githubusercontent.com/johrstrom/jmeter-prometheus-plugin/master/docs/imgs/simple_testplan.png",
     "helpUrl": "https://github.com/johrstrom/jmeter-prometheus-plugin",
-    "vendor": "",
+    "vendor": "johrstrom",
+    "markerClass": "com.github.johrstrom.collector.SuccessRatioCollector",
+    "componentClasses": [
+      "com.github.johrstrom.listener.PrometheusListener"
+    ],
     "versions": {
       "0.6.0": {
         "downloadUrl": "https://github.com/johrstrom/jmeter-prometheus-plugin/releases/download/0.6.0/jmeter-prometheus-plugin-0.6.0.jar",


### PR DESCRIPTION
Add Jmeter prometheus plugin as suggested here: https://github.com/johrstrom/jmeter-prometheus-plugin/issues/82

I've removed markerClass and componentClasses from the same as I'm not sure what they should refer to.