### PR TITLE
RTE-Plugin minor release 3.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -833,6 +833,15 @@
           "dm3270-lib>=0.12.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/dm3270-lib-0.12.3.jar",
           "jVT220>=1.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.0.1/jVT220-1.3.jar"
         }
+      },
+      "3.1": {
+        "changes": "Send attention key to a determined position, and some bug fix!",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1/jmeter-bzm-rte-3.1.jar",
+        "libs": {
+          "xtn5250>=3.2.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1/xtn5250-3.2.2.jar",
+          "dm3270-lib>=0.12.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1/dm3270-lib-0.12.3.2.jar",
+          "jVT220>=1.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1/jVT220-1.3.1.jar"
+        }
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -858,7 +858,6 @@
         "changes": "Siebel Plugin has evolved into Correlation Recorder with lots of new features. Please check documentation to learn about all the new goodies!",
         "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.0/jmeter-bzm-correlation-recorder-1.0.jar",
         "libs": {
-          "swingx-all>=1.6.5.1": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.0/swingx-all-1.6.5-1.jar",
           "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.0/jackson-dataformat-xml-2.10.2.jar",
           "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.0/jackson-annotations-2.10.2.jar",
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.0/jackson-databind-2.10.2.jar",


### PR DESCRIPTION
What's new on this minor release:
1. Fix issue when sending Attention Key on screens not constituted by fields. (TN5250 protocol)
1. **Add support for sending an attention key at a determined position**. This feature is very useful for scenarios where screens aren't constituted by fields, and there is a menu waiting for an ENTER key to be pressed on the desired position.
   > In order to set the cursor position when building manually the TestPlan, would be adding a **Position Input** with the coordinates where we want to place the cursor, and then, is mandatory to set the value of the input, empty. The Recorder will do this automatically. For more information click [here](https://github.com/Blazemeter/RTEPlugin#sampler-rte-sampler)
1. Fix issue when the sample name kept changing when sending inputs using VT420 protocol alongside with the Recorder.