### PR TITLE
Remove old LoggingManager and Logger

### DIFF
--- a/graphs/graphs-additional/src/main/java/kg/apc/jmeter/vizualizers/BytesThroughputOverTimeGui.java
+++ b/graphs/graphs-additional/src/main/java/kg/apc/jmeter/vizualizers/BytesThroughputOverTimeGui.java
@@ -10,7 +10,7 @@ import org.apache.jmeter.samplers.SampleResult;
 
 public class BytesThroughputOverTimeGui
         extends AbstractOverTimeVisualizer {
-    //private static final Logger log = LoggingManager.getLoggerForClass();
+    //private static final Logger log = LoggerFactory.getLogger(BytesThroughputOverTimeGui.class);
 
     private static Method sentBytesMethod;
     

--- a/graphs/graphs-basic/src/main/java/kg/apc/jmeter/vizualizers/ThreadsStateOverTimeGui.java
+++ b/graphs/graphs-basic/src/main/java/kg/apc/jmeter/vizualizers/ThreadsStateOverTimeGui.java
@@ -9,13 +9,13 @@ import kg.apc.charting.rows.GraphRowSimple;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.graphs.AbstractOverTimeVisualizer;
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class ThreadsStateOverTimeGui
         extends AbstractOverTimeVisualizer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ThreadsStateOverTimeGui.class);
     private long lastAggUpdateTime = 0;
 
     /**

--- a/graphs/graphs-basic/src/main/java/kg/apc/jmeter/vizualizers/TransactionsPerSecondGui.java
+++ b/graphs/graphs-basic/src/main/java/kg/apc/jmeter/vizualizers/TransactionsPerSecondGui.java
@@ -8,7 +8,7 @@ import org.apache.jmeter.samplers.SampleResult;
 
 public class TransactionsPerSecondGui
         extends AbstractOverTimeVisualizer {
-    //private static final Logger log = LoggingManager.getLoggerForClass();
+    //private static final Logger log = LoggerFactory.getLogger(TransactionsPerSecondGui.class);
 
     /**
      *

--- a/infra/common-io/src/main/java/kg/apc/io/DatagramChannelWithTimeouts.java
+++ b/infra/common-io/src/main/java/kg/apc/io/DatagramChannelWithTimeouts.java
@@ -13,8 +13,8 @@ import java.nio.channels.MembershipKey;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.util.Set;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class DatagramChannelWithTimeouts extends DatagramChannel {
 
@@ -22,7 +22,7 @@ public class DatagramChannelWithTimeouts extends DatagramChannel {
     protected Selector selector;
     private long readTimeout = 10000;
     protected SelectionKey channelKey;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DatagramChannelWithTimeouts.class);
     private boolean fastFirstPacketRead;
 
     protected DatagramChannelWithTimeouts() throws IOException {

--- a/infra/common-io/src/main/java/kg/apc/io/SocketChannelWithTimeouts.java
+++ b/infra/common-io/src/main/java/kg/apc/io/SocketChannelWithTimeouts.java
@@ -11,8 +11,8 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.util.Set;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 // IMPORTANT: we have troubles with Java 6 to 7 compatibility here
 // SEE: http://www.oracle.com/technetwork/java/javase/compatibility-417013.html#incompatibilities
@@ -30,7 +30,7 @@ public class SocketChannelWithTimeouts extends SocketChannel {
     private long connectTimeout = 5000;
     private long readTimeout = 10000;
     protected SelectionKey channelKey;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SocketChannelWithTimeouts.class);
     private boolean fastFirstPacketRead;
 
     protected SocketChannelWithTimeouts() throws IOException {

--- a/infra/common-io/src/main/java/kg/apc/jmeter/samplers/AbstractIPSampler.java
+++ b/infra/common-io/src/main/java/kg/apc/jmeter/samplers/AbstractIPSampler.java
@@ -6,8 +6,8 @@ import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -19,7 +19,7 @@ public abstract class AbstractIPSampler
         extends AbstractSampler
         implements Serializable, Cloneable, Interruptible {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractIPSampler.class);
     public static final String RECV_BUFFER_LEN_PROPERTY = "kg.apc.jmeter.samplers.ReceiveBufferSize";
     public static final String RESULT_DATA_LIMIT = "kg.apc.jmeter.samplers.ResultDataLimit";
     public static final String HOSTNAME = "hostname";

--- a/infra/common/src/main/java/kg/apc/charting/ColorsDispatcherFactory.java
+++ b/infra/common/src/main/java/kg/apc/charting/ColorsDispatcherFactory.java
@@ -3,13 +3,13 @@ package kg.apc.charting;
 import java.io.Serializable;
 
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import kg.apc.charting.colors.*;
 
 public class ColorsDispatcherFactory implements Serializable {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ColorsDispatcherFactory.class);
 
     public static ColorsDispatcher getColorsDispatcher() {
         String customDispatcher = JMeterUtils.getProperty("jmeterPlugin.customColorsDispatcher");

--- a/infra/common/src/main/java/kg/apc/charting/DateTimeRenderer.java
+++ b/infra/common/src/main/java/kg/apc/charting/DateTimeRenderer.java
@@ -4,13 +4,13 @@ import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
 import org.apache.jorphan.gui.NumberRenderer;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class DateTimeRenderer
         extends NumberRenderer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DateTimeRenderer.class);
     protected final SimpleDateFormat dateFormatter;
     private long relativeStartTime = 0;
     private static final String EMPTY = "";

--- a/infra/common/src/main/java/kg/apc/charting/GraphPanelChart.java
+++ b/infra/common/src/main/java/kg/apc/charting/GraphPanelChart.java
@@ -6,8 +6,8 @@ import kg.apc.charting.plotters.CSplineRowPlotter;
 import kg.apc.charting.plotters.LineRowPlotter;
 import kg.apc.jmeter.gui.CustomNumberRenderer;
 import org.apache.jorphan.gui.NumberRenderer;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -59,7 +59,7 @@ public class GraphPanelChart
      */
     public static final int CHART_PERCENTAGE = 0;
     public static final int CHART_DEFAULT = -1;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(GraphPanelChart.class);
     private Rectangle legendRect;
     private Rectangle xAxisRect;
     private Rectangle yAxisRect;

--- a/infra/common/src/main/java/kg/apc/charting/LabelToColorMapping.java
+++ b/infra/common/src/main/java/kg/apc/charting/LabelToColorMapping.java
@@ -5,12 +5,12 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class LabelToColorMapping {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LabelToColorMapping.class);
 	
 	public LabelToColorMapping() {
 		loadStandardHtmlColors();

--- a/infra/common/src/main/java/kg/apc/charting/colors/CustomPalette.java
+++ b/infra/common/src/main/java/kg/apc/charting/colors/CustomPalette.java
@@ -1,8 +1,8 @@
 package kg.apc.charting.colors;
 
 import kg.apc.charting.ColorsDispatcher;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import java.util.List;
  */
 public class CustomPalette implements ColorsDispatcher {
     List<Color> customPalette = new ArrayList<Color>(16);
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(CustomPalette.class);
 
     int i = 0;
 

--- a/infra/common/src/main/java/kg/apc/charting/colors/CycleColors.java
+++ b/infra/common/src/main/java/kg/apc/charting/colors/CycleColors.java
@@ -1,14 +1,14 @@
 package kg.apc.charting.colors;
 
 import kg.apc.charting.ColorsDispatcher;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.awt.*;
 import java.util.*;
 
 public class CycleColors implements ColorsDispatcher {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(CycleColors.class);
     private java.util.List<Color> assignedColors = new ArrayList<>();
     private final static int LEVEL_MAX = 256;
     private int level;

--- a/infra/common/src/main/java/kg/apc/charting/colors/HueRotatePalette.java
+++ b/infra/common/src/main/java/kg/apc/charting/colors/HueRotatePalette.java
@@ -1,8 +1,8 @@
 package kg.apc.charting.colors;
 
 import kg.apc.charting.ColorsDispatcher;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class HueRotatePalette implements ColorsDispatcher {
     List<Color> customPalette = new ArrayList<>(16);
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(HueRotatePalette.class);
     private static final int startingGradient = 0x000;
     private static final int maxGradient = 120;
     int i = 0;

--- a/infra/common/src/main/java/kg/apc/charting/rows/GraphRowPercentiles.java
+++ b/infra/common/src/main/java/kg/apc/charting/rows/GraphRowPercentiles.java
@@ -5,12 +5,12 @@ import kg.apc.charting.AbstractGraphPanelChartElement;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentSkipListMap;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class GraphRowPercentiles extends GraphRowSumValues {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(GraphRowPercentiles.class);
     private ConcurrentSkipListMap<Long, AbstractGraphPanelChartElement> percentiles = new ConcurrentSkipListMap<Long, AbstractGraphPanelChartElement>();
     private long totalCount = 0L;
     private static final int FRACTION = 10;

--- a/infra/common/src/main/java/kg/apc/charting/rows/GraphRowSumValues.java
+++ b/infra/common/src/main/java/kg/apc/charting/rows/GraphRowSumValues.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 public class GraphRowSumValues
         extends AbstractGraphRow
         implements Iterator<Entry<Long, AbstractGraphPanelChartElement>> {
-    //private static final Logger log = LoggingManager.getLoggerForClass();
+    //private static final Logger log = LoggerFactory.getLogger(GraphRowSumValues.class);
 
     private ConcurrentSkipListMap<Long, GraphPanelChartSumElement> values;
     private double rollingSum;

--- a/infra/common/src/main/java/kg/apc/jmeter/JMeterPluginsUtils.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/JMeterPluginsUtils.java
@@ -8,8 +8,8 @@ import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public abstract class JMeterPluginsUtils {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JMeterPluginsUtils.class);
 
     private static final String PLUGINS_PREFIX = "jp@gc - ";
     private static boolean prefixPlugins = true;
@@ -490,7 +490,6 @@ public abstract class JMeterPluginsUtils {
                     Properties tmp = new Properties();
                     tmp.load(fis);
                     jmeterProps.putAll(tmp);
-                    LoggingManager.setLoggingLevels(jmeterProps);//Do what would be done earlier
                 }
             } catch (IOException e) {
                 log.warn("Error loading user property file: " + userProp, e);

--- a/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractGraphPanelVisualizer.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractGraphPanelVisualizer.java
@@ -20,8 +20,8 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.ImageVisualizer;
 import org.apache.jmeter.visualizers.Sample;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -41,7 +41,7 @@ public abstract class AbstractGraphPanelVisualizer
         ImageVisualizer,
         SettingsInterface {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractGraphPanelVisualizer.class);
     /**
      *
      */

--- a/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizer.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/graphs/AbstractMonitoringVisualizer.java
@@ -18,8 +18,8 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * Generic class for plotting monitoring results over time.
@@ -28,7 +28,7 @@ import org.apache.log.Logger;
 public abstract class AbstractMonitoringVisualizer
         extends AbstractOverTimeVisualizer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractMonitoringVisualizer.class);
     protected PowerTableModel tableModel;
     protected JTable grid;
     protected JTextArea errorTextArea;

--- a/infra/common/src/main/java/kg/apc/jmeter/graphs/GraphPanel.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/graphs/GraphPanel.java
@@ -14,13 +14,13 @@ import javax.swing.event.ChangeListener;
 import kg.apc.charting.AbstractGraphRow;
 import kg.apc.charting.GraphPanelChart;
 import org.apache.jmeter.gui.GuiPackage;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class GraphPanel
         extends JTabbedPane {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(GraphPanel.class);
     private GraphPanelChart graphPanelObject;
     private JRowsSelectorPanel rowsTab;
     private JComponent settingsTab;

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/CorrectedResultCollector.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/CorrectedResultCollector.java
@@ -6,12 +6,12 @@ import java.util.List;
 
 import org.apache.jmeter.reporters.ResultCollector;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class CorrectedResultCollector extends ResultCollector {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(CorrectedResultCollector.class);
     public static final String INCLUDE_SAMPLE_LABELS = "include_sample_labels";
     public static final String EXCLUDE_SAMPLE_LABELS = "exclude_sample_labels";
     public static final String INCLUDE_REGEX_CHECKBOX_STATE = "include_checkbox_state";

--- a/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
+++ b/infra/common/src/main/java/kg/apc/jmeter/vizualizers/MonitoringResultsCollector.java
@@ -13,8 +13,8 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import kg.apc.jmeter.JMeterPluginsUtils;
 
@@ -24,7 +24,7 @@ public class MonitoringResultsCollector
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(MonitoringResultsCollector.class);
     public static final String DATA_PROPERTY = "samplers";
 
     private int interval;

--- a/infra/common/src/main/java/kg/apc/logging/LoggingUtils.java
+++ b/infra/common/src/main/java/kg/apc/logging/LoggingUtils.java
@@ -1,12 +1,12 @@
 package kg.apc.logging;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.lang.reflect.Constructor;
 
 public class LoggingUtils {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LoggingUtils.class);
 
     public static void addLoggingConfig() {
         if (isJMeter32orLater()) {

--- a/infra/emulators/src/main/java/kg/apc/emulators/DatagramChannelEmul.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/DatagramChannelEmul.java
@@ -1,7 +1,7 @@
 package kg.apc.emulators;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.*;
@@ -15,7 +15,7 @@ public class DatagramChannelEmul extends DatagramChannel {
 
     private ByteBuffer writtenBytes;
     private ByteBuffer bytesToRead;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DatagramChannelEmul.class);
     private DatagramSocket socket;
 
     public DatagramChannelEmul() {

--- a/infra/emulators/src/main/java/kg/apc/emulators/DatagramSocketEmulator.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/DatagramSocketEmulator.java
@@ -1,7 +1,7 @@
 package kg.apc.emulators;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -12,7 +12,7 @@ import java.net.SocketException;
 public class DatagramSocketEmulator
         extends DatagramSocket {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DatagramSocketEmulator.class);
     private DatagramPacket toRead;
 
     public DatagramSocketEmulator() throws SocketException {

--- a/infra/emulators/src/main/java/kg/apc/emulators/EmulatorJmeterEngine.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/EmulatorJmeterEngine.java
@@ -1,11 +1,11 @@
 package kg.apc.emulators;
 
 import org.apache.jmeter.engine.StandardJMeterEngine;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class EmulatorJmeterEngine extends StandardJMeterEngine{
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(EmulatorJmeterEngine.class);
 
     @Override
     public void askThreadsToStop() {

--- a/infra/emulators/src/main/java/kg/apc/emulators/EmulatorThreadMonitor.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/EmulatorThreadMonitor.java
@@ -2,11 +2,11 @@ package kg.apc.emulators;
 
 import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.JMeterThreadMonitor;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class EmulatorThreadMonitor implements JMeterThreadMonitor {
-   private static final Logger log = LoggingManager.getLoggerForClass();
+   private static final Logger log = LoggerFactory.getLogger(EmulatorThreadMonitor.class);
 
    @Override
    public void threadFinished(JMeterThread jmt) {

--- a/infra/emulators/src/main/java/kg/apc/emulators/FileChannelEmul.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/FileChannelEmul.java
@@ -1,7 +1,7 @@
 package kg.apc.emulators;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -15,7 +15,7 @@ public class FileChannelEmul extends FileChannel {
 
     private ByteBuffer writtenBytes;
     private ByteBuffer bytesToRead;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FileChannelEmul.class);
 
     public FileChannelEmul() {
         super();

--- a/infra/emulators/src/main/java/kg/apc/emulators/FileLockEmul.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/FileLockEmul.java
@@ -8,11 +8,11 @@ package kg.apc.emulators;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 class FileLockEmul extends FileLock {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FileLockEmul.class);
 
     public FileLockEmul() {
         super((FileChannel) null, 0, 0, false);

--- a/infra/emulators/src/main/java/kg/apc/emulators/SocketChannelEmul.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/SocketChannelEmul.java
@@ -1,7 +1,7 @@
 package kg.apc.emulators;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -16,7 +16,7 @@ public class SocketChannelEmul extends SocketChannel {
     private int writtenBytesCount;
     private ByteBuffer writtenBytes;
     private ByteBuffer bytesToRead;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SocketChannelEmul.class);
     private Socket socket = new SocketEmulator();
 
     public SocketChannelEmul() {

--- a/infra/emulators/src/main/java/kg/apc/emulators/SocketEmulatorInputStream.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/SocketEmulatorInputStream.java
@@ -1,13 +1,13 @@
 package kg.apc.emulators;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 public class SocketEmulatorInputStream extends InputStream {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SocketEmulatorInputStream.class);
     private byte[] bytes;
     private int pos = 0;
 

--- a/infra/emulators/src/main/java/kg/apc/emulators/TestGraphics.java
+++ b/infra/emulators/src/main/java/kg/apc/emulators/TestGraphics.java
@@ -24,13 +24,13 @@ import java.awt.image.RenderedImage;
 import java.awt.image.renderable.RenderableImage;
 import java.text.AttributedCharacterIterator;
 import java.util.Map;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class TestGraphics
      extends Graphics2D
 {
-   private static final Logger log = LoggingManager.getLoggerForClass();
+   private static final Logger log = LoggerFactory.getLogger(TestGraphics.class);
 
    /**
     *

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
@@ -11,8 +11,8 @@ import org.apache.jmeter.samplers.SampleListener;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 import java.net.DatagramPacket;
@@ -24,7 +24,7 @@ public class AutoStop
         implements SampleListener, Serializable,
         TestStateListener, Remoteable, NoThreadClone {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AutoStop.class);
     private final static String RESPONSE_TIME = "avg_response_time";
     private final static String ERROR_RATE = "error_rate";
     private final static String RESPONSE_TIME_SECS = "avg_response_time_length";

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStopGui.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStopGui.java
@@ -5,12 +5,12 @@ import javax.swing.JPanel;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class AutoStopGui extends AbstractListenerGui {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AutoStopGui.class);
     public static final String WIKIPAGE = "AutoStop";
     private JAutoStopPanel autoStopPanel;
 

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/control/VirtualUserController.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/control/VirtualUserController.java
@@ -9,11 +9,11 @@ import org.apache.jmeter.control.NextIsNullException;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterThread;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class VirtualUserController extends GenericController {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(VirtualUserController.class);
     private boolean hasArrived = false;
     protected AbstractDynamicThreadGroup owner;
 

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/reporters/FlushingResultCollector.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/reporters/FlushingResultCollector.java
@@ -1,11 +1,11 @@
 package com.blazemeter.jmeter.reporters;
 
 import org.apache.jmeter.reporters.ResultCollector;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class FlushingResultCollector extends ResultCollector {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FlushingResultCollector.class);
 
     public FlushingResultCollector() {
         super();

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroup.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroup.java
@@ -6,14 +6,14 @@ import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Set;
 
 // adding some basic methods to our Model
 public abstract class AbstractDynamicThreadGroup extends AbstractDynamicThreadGroupModel {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractDynamicThreadGroup.class);
     public static final String UNIT = "Unit";
     public static final String UNIT_MINUTES = "M";
     public static final String UNIT_SECONDS = "S";

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroupGui.java
@@ -10,8 +10,8 @@ import kg.apc.jmeter.gui.GuiBuilderHelper;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.gui.AbstractThreadGroupGui;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractDynamicThreadGroupGui extends AbstractThreadGroupGui
         implements DocumentListener, Runnable, ActionListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractDynamicThreadGroupGui.class);
     protected GraphPanelChart previewChart;
     protected ConcurrentHashMap<String, AbstractGraphRow> chartModel;
     protected boolean uiCreated = false;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroupModel.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractDynamicThreadGroupModel.java
@@ -12,14 +12,14 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import com.blazemeter.jmeter.reporters.FlushingResultCollector;
 
 // reason to have this class as separate is will to keep Model responsibility separate
 public abstract class AbstractDynamicThreadGroupModel extends AbstractThreadGroup implements TestStateListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractDynamicThreadGroupModel.class);
     protected static final long WAIT_TO_DIE = JMeterUtils.getPropDefault("jmeterengine.threadstop.wait", 5 * 1000);
     public static final String LOG_FILENAME = "LogFilename";
     public static final String TARGET_LEVEL = "TargetLevel";

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractThreadStarter.java
@@ -11,11 +11,11 @@ import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public abstract class AbstractThreadStarter extends Thread {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractThreadStarter.class);
     protected final ListenerNotifier notifier;
     protected final ListedHashTree threadGroupTree;
     protected final StandardJMeterEngine engine;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/LoadParamsFieldsPanel.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/LoadParamsFieldsPanel.java
@@ -2,14 +2,14 @@ package com.blazemeter.jmeter.threads;
 
 import com.blazemeter.jmeter.gui.ArrangedLabelFieldPanel;
 import kg.apc.jmeter.JMeterVariableEvaluator;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.event.DocumentListener;
 
 public class LoadParamsFieldsPanel extends ArrangedLabelFieldPanel implements ParamsPanel {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LoadParamsFieldsPanel.class);
 
     protected JTextField targetRate = new JTextField();
     protected JTextField rampUpTime = new JTextField();

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroup.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroup.java
@@ -8,8 +8,8 @@ import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jmeter.threads.ThreadCountsAccessor;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Collections;
 import java.util.Set;
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ArrivalsThreadGroup extends AbstractDynamicThreadGroup {
     public static final String CONCURRENCY_LIMIT = "ConcurrencyLimit";
     public static final String ARRIVALS_LIMIT = "ArrivalsLimit";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ArrivalsThreadGroup.class);
     protected final AtomicLong arrivalsCount = new AtomicLong();
     protected final AtomicLong completionsCount = new AtomicLong();
     protected AtomicLong abandonsCount = new AtomicLong();

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroupGui.java
@@ -2,13 +2,13 @@ package com.blazemeter.jmeter.threads.arrivals;
 
 import com.blazemeter.jmeter.threads.*;
 import kg.apc.jmeter.JMeterPluginsUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.awt.*;
 
 public class ArrivalsThreadGroupGui extends AbstractDynamicThreadGroupGui {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ArrivalsThreadGroupGui.class);
 
     public ArrivalsThreadGroupGui() {
         super();

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadStarter.java
@@ -4,11 +4,11 @@ import com.blazemeter.jmeter.threads.AbstractThreadStarter;
 import org.apache.jmeter.engine.StandardJMeterEngine;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class ArrivalsThreadStarter extends AbstractThreadStarter {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ArrivalsThreadStarter.class);
     private ArrivalsThreadGroup arrivalsTG;
     protected long scheduledCount = 0;
     protected double rollingTime = 0;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroupGui.java
@@ -11,8 +11,8 @@ import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.JMeterVariableEvaluator;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.event.DocumentListener;
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 
 public class FreeFormArrivalsThreadGroupGui extends AbstractDynamicThreadGroupGui implements TableModelListener, DocumentListener, Runnable, ActionListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FreeFormArrivalsThreadGroupGui.class);
 
     public FreeFormArrivalsThreadGroupGui() {
         super();

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarter.java
@@ -6,11 +6,11 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class FreeFormArrivalsThreadStarter extends ArrivalsThreadStarter {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FreeFormArrivalsThreadStarter.class);
     private final FreeFormArrivalsThreadGroup arrivalsTG;
 
     public FreeFormArrivalsThreadStarter(int groupIndex, ListenerNotifier listenerNotifier, ListedHashTree listedHashTree, StandardJMeterEngine standardJMeterEngine, FreeFormArrivalsThreadGroup owner) {

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadGroup.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadGroup.java
@@ -12,13 +12,13 @@ import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import com.blazemeter.jmeter.threads.AbstractDynamicThreadGroup;
 
 public class ConcurrencyThreadGroup extends AbstractDynamicThreadGroup {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ConcurrencyThreadGroup.class);
     private static final long DEFAULT_TEMPORISATION = JMeterUtils.getPropDefault("dynamic_tg.temporisation", 10L);
 
     public static final long MIN_CHECK_TIME = 1000L;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadStarter.java
@@ -4,14 +4,14 @@ import org.apache.jmeter.engine.StandardJMeterEngine;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import com.blazemeter.jmeter.threads.AbstractThreadStarter;
 import com.blazemeter.jmeter.threads.DynamicThread;
 
 public class ConcurrencyThreadStarter extends AbstractThreadStarter {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ConcurrencyThreadStarter.class);
     static final long CACHING_VALIDITY_MS = JMeterUtils.getPropDefault("dynamic_tg.properties_caching_validity", 20L);
 
     private final ConcurrencyThreadGroup concurrTG;

--- a/plugins/casutg/src/main/java/kg/apc/jmeter/threads/AbstractSimpleThreadGroup.java
+++ b/plugins/casutg/src/main/java/kg/apc/jmeter/threads/AbstractSimpleThreadGroup.java
@@ -13,11 +13,11 @@ import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public abstract class AbstractSimpleThreadGroup extends AbstractThreadGroup {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractSimpleThreadGroup.class);
 
     private static final long WAIT_TO_DIE = JMeterUtils.getPropDefault("jmeterengine.threadstop.wait", 5 * 1000); // 5 seconds
     public static final String THREAD_GROUP_DISTRIBUTED_PREFIX_PROPERTY_NAME = "__jm.D_TG"; // FIXME: use JMeterUtils.THREAD_GROUP_DISTRIBUTED_PREFIX_PROPERTY_NAME when dependency is updated

--- a/plugins/casutg/src/main/java/kg/apc/jmeter/threads/SteppingThreadGroup.java
+++ b/plugins/casutg/src/main/java/kg/apc/jmeter/threads/SteppingThreadGroup.java
@@ -1,15 +1,15 @@
 package kg.apc.jmeter.threads;
 
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 import org.apache.jmeter.threads.JMeterThread;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 
 @Deprecated
 public class SteppingThreadGroup
         extends AbstractSimpleThreadGroup {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SteppingThreadGroup.class);
     private static final String THREAD_GROUP_DELAY = "Threads initial delay";
     private static final String INC_USER_PERIOD = "Start users period";
     private static final String INC_USER_COUNT = "Start users count";

--- a/plugins/casutg/src/main/java/kg/apc/jmeter/threads/UltimateThreadGroup.java
+++ b/plugins/casutg/src/main/java/kg/apc/jmeter/threads/UltimateThreadGroup.java
@@ -9,8 +9,8 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -20,7 +20,7 @@ public class UltimateThreadGroup
         extends AbstractSimpleThreadGroup
         implements Serializable, TestStateListener {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(UltimateThreadGroup.class);
 
     public static final String DATA_PROPERTY = "ultimatethreadgroupdata";
     public static final String EXTERNAL_DATA_PROPERTY = "threads_schedule";

--- a/plugins/casutg/src/main/java/kg/apc/jmeter/threads/UltimateThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/kg/apc/jmeter/threads/UltimateThreadGroupGui.java
@@ -19,8 +19,8 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.gui.AbstractThreadGroupGui;
 import org.apache.jorphan.collections.HashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import javax.swing.event.CellEditorListener;
@@ -36,7 +36,7 @@ public class UltimateThreadGroupGui
         CellEditorListener {
 
     public static final String WIKIPAGE = "UltimateThreadGroup";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(UltimateThreadGroupGui.class);
     protected ConcurrentHashMap<String, AbstractGraphRow> model;
     private GraphPanelChart chart;
     public static final String[] columnIdentifiers = new String[]{

--- a/plugins/casutg/src/test/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarterTest.java
+++ b/plugins/casutg/src/test/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarterTest.java
@@ -6,15 +6,15 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.LinkedHashSet;
 
 public class FreeFormArrivalsThreadStarterTest {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FreeFormArrivalsThreadStarterTest.class);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/plugins/csl/src/main/java/kg/apc/jmeter/reporters/ConsoleStatusLogger.java
+++ b/plugins/csl/src/main/java/kg/apc/jmeter/reporters/ConsoleStatusLogger.java
@@ -14,14 +14,14 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestListener;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterContextService;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class ConsoleStatusLogger extends AbstractListenerElement
         implements SampleListener, Serializable,
         NoThreadClone, TestStateListener {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ConsoleStatusLogger.class);
     private PrintStream out;
     private long cur = 0;
     private int count;

--- a/plugins/csvars/src/main/java/kg/apc/jmeter/config/VariableFromCsvFileReader.java
+++ b/plugins/csvars/src/main/java/kg/apc/jmeter/config/VariableFromCsvFileReader.java
@@ -6,13 +6,13 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 public class VariableFromCsvFileReader {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(VariableFromCsvFileReader.class);
     private BufferedReader input;
 
     /**

--- a/plugins/dbmon/src/main/java/kg/apc/jmeter/dbmon/DbMonCollector.java
+++ b/plugins/dbmon/src/main/java/kg/apc/jmeter/dbmon/DbMonCollector.java
@@ -18,8 +18,8 @@ import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class DbMonCollector
         extends CorrectedResultCollector
@@ -32,7 +32,7 @@ public class DbMonCollector
 	
 	private static boolean autoGenerateFiles = false;
     private static final String DBMON = "DbMon";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DbMonCollector.class);
     public static final String DATA_PROPERTY = "samplers";
     private int interval;
     private Thread workerThread = null;

--- a/plugins/dbmon/src/main/java/kg/apc/jmeter/dbmon/DbMonSampler.java
+++ b/plugins/dbmon/src/main/java/kg/apc/jmeter/dbmon/DbMonSampler.java
@@ -4,12 +4,12 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class DbMonSampler {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DbMonSampler.class);
     private String metricName;
     private String sql;
     private String poolName;

--- a/plugins/dbmon/src/main/java/kg/apc/jmeter/vizualizers/DbMonGui.java
+++ b/plugins/dbmon/src/main/java/kg/apc/jmeter/vizualizers/DbMonGui.java
@@ -17,13 +17,13 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class DbMonGui
         extends AbstractOverTimeVisualizer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DbMonGui.class);
     private PowerTableModel tableModel;
     private JTable grid;
     private JTextArea errorTextArea;

--- a/plugins/deprecated/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
+++ b/plugins/deprecated/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
@@ -21,8 +21,8 @@ import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.JMeterContext;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.w3c.dom.Document;
 
 /**
@@ -32,7 +32,7 @@ import org.w3c.dom.Document;
 public class XMLFormatPostProcessor extends AbstractTestElement implements
         Cloneable, Serializable, PostProcessor, TestElement {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(XMLFormatPostProcessor.class);
     private static final long serialVersionUID = -4885245911424989596L;
 
     public void process() {

--- a/plugins/deprecated/src/main/java/kg/apc/jmeter/config/DistributedTestControl.java
+++ b/plugins/deprecated/src/main/java/kg/apc/jmeter/config/DistributedTestControl.java
@@ -4,8 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -14,7 +14,7 @@ public class DistributedTestControl extends ConfigTestElement {
 
     public static final String DATA_PROP = "SERVERS";
     public static final String PROP_HOSTS = "remote_hosts";
-    public static Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DistributedTestControl.class);
 
     public CollectionProperty getData() {
         CollectionProperty data = (CollectionProperty) getProperty(DATA_PROP);

--- a/plugins/deprecated/src/main/java/kg/apc/jmeter/config/DistributedTestControlGui.java
+++ b/plugins/deprecated/src/main/java/kg/apc/jmeter/config/DistributedTestControlGui.java
@@ -4,8 +4,8 @@ import kg.apc.jmeter.JMeterPluginsUtils;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -16,7 +16,7 @@ import java.util.Collection;
 public class DistributedTestControlGui extends AbstractConfigGui {
 
     public static final String WIKIPAGE = "DistributedTestControl";
-    public static Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DistributedTestControlGui.class);
     private ServersListPanel serversPanel;
 
     public DistributedTestControlGui() {

--- a/plugins/deprecated/src/main/java/kg/apc/jmeter/config/ServersListPanel.java
+++ b/plugins/deprecated/src/main/java/kg/apc/jmeter/config/ServersListPanel.java
@@ -1,8 +1,8 @@
 package kg.apc.jmeter.config;
 
 import org.apache.jmeter.testelement.property.CollectionProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -10,7 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class ServersListPanel extends JPanel {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ServersListPanel.class);
 
     private List<JMeterServerPanel> serversList;
 

--- a/plugins/dummy/src/main/java/kg/apc/jmeter/dummy/DummyElement.java
+++ b/plugins/dummy/src/main/java/kg/apc/jmeter/dummy/DummyElement.java
@@ -2,8 +2,8 @@ package kg.apc.jmeter.dummy;
 
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
@@ -12,7 +12,7 @@ import java.net.URL;
 
 public class DummyElement implements Serializable {
     private static final long serialVersionUID = 246L;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DummyElement.class);
 
     public static final String IS_SUCCESSFUL = "SUCCESFULL";
     public static final String RESPONSE_CODE = "RESPONSE_CODE";

--- a/plugins/ffw/src/main/java/kg/apc/jmeter/reporters/FlexibleFileWriter.java
+++ b/plugins/ffw/src/main/java/kg/apc/jmeter/reporters/FlexibleFileWriter.java
@@ -12,8 +12,8 @@ import org.apache.jmeter.samplers.SampleListener;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -46,7 +46,7 @@ public class FlexibleFileWriter
             + "threadsCount requestHeaders connectTime "
             + "grpThreads sampleCount errorCount "
             + "responseHeaderSize responseSize URL";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FlexibleFileWriter.class);
     private static final String OVERWRITE = "overwrite";
     private static final String FILENAME = "filename";
     private static final String COLUMNS = "columns";

--- a/plugins/fifo/src/main/java/kg/apc/jmeter/functions/FifoPop.java
+++ b/plugins/fifo/src/main/java/kg/apc/jmeter/functions/FifoPop.java
@@ -8,15 +8,15 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 public class FifoPop extends AbstractFunction {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FifoPop.class);
 
     private static final List<String> desc = new LinkedList<String>();
     private static final String KEY = "__fifoPop";

--- a/plugins/fifo/src/main/java/kg/apc/jmeter/functions/FifoPut.java
+++ b/plugins/fifo/src/main/java/kg/apc/jmeter/functions/FifoPut.java
@@ -6,15 +6,15 @@ import org.apache.jmeter.functions.AbstractFunction;
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 public class FifoPut extends AbstractFunction {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FifoPut.class);
 
     private static final List<String> desc = new LinkedList<String>();
     private static final String KEY = "__fifoPut";

--- a/plugins/fifo/src/main/java/kg/apc/jmeter/modifiers/FifoPopPreProcessor.java
+++ b/plugins/fifo/src/main/java/kg/apc/jmeter/modifiers/FifoPopPreProcessor.java
@@ -6,13 +6,13 @@ import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class FifoPopPreProcessor extends AbstractTestElement
         implements PreProcessor, TestStateListener {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FifoPopPreProcessor.class);
 
     public static final String queueName = "FifoName";
     public static final String variableName = "Variable";

--- a/plugins/fifo/src/main/java/kg/apc/jmeter/modifiers/FifoPutPostProcessor.java
+++ b/plugins/fifo/src/main/java/kg/apc/jmeter/modifiers/FifoPutPostProcessor.java
@@ -3,12 +3,12 @@ package kg.apc.jmeter.modifiers;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestStateListener;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class FifoPutPostProcessor extends AbstractTestElement
         implements PostProcessor, TestStateListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FifoPutPostProcessor.class);
 
     public static final String QUEUE = "FifoName";
     public static final String VALUE = "Value";

--- a/plugins/functions/src/main/java/kg/apc/jmeter/functions/Substring.java
+++ b/plugins/functions/src/main/java/kg/apc/jmeter/functions/Substring.java
@@ -10,8 +10,6 @@ import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 
 public class Substring extends AbstractFunction {
 

--- a/plugins/httpraw/src/main/java/kg/apc/jmeter/modifiers/CheckConsistencyAction.java
+++ b/plugins/httpraw/src/main/java/kg/apc/jmeter/modifiers/CheckConsistencyAction.java
@@ -8,11 +8,11 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.RuntimeEOFException;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class CheckConsistencyAction implements ActionListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(CheckConsistencyAction.class);
     private final JTextField filename;
     private final JTextArea infoArea;
 

--- a/plugins/httpraw/src/main/java/kg/apc/jmeter/modifiers/RawRequestSourcePreProcessor.java
+++ b/plugins/httpraw/src/main/java/kg/apc/jmeter/modifiers/RawRequestSourcePreProcessor.java
@@ -17,16 +17,16 @@ import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 public class RawRequestSourcePreProcessor
         extends AbstractTestElement
         implements PreProcessor, NoThreadClone, TestStateListener {
 
     public static final String regexp = "\\s";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(RawRequestSourcePreProcessor.class);
     public static final String VARIABLE_NAME = "variable_name";
     public static final String FILENAME = "filename";
     public static final String REWIND = "rewind";

--- a/plugins/httpraw/src/main/java/kg/apc/jmeter/samplers/HTTPRawSampler.java
+++ b/plugins/httpraw/src/main/java/kg/apc/jmeter/samplers/HTTPRawSampler.java
@@ -15,8 +15,8 @@ import kg.apc.io.SocketChannelWithTimeouts;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // FIXME: actually keep-alive does not work!
 public class HTTPRawSampler extends AbstractIPSampler {
@@ -27,7 +27,7 @@ public class HTTPRawSampler extends AbstractIPSampler {
     private static final String RNpattern = "\\r\\n";
     private static final String SPACE = " ";
     // 
-    protected static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(HTTPRawSampler.class);
     private static final Pattern anyContent = Pattern.compile(".+", Pattern.DOTALL);
     private SocketChannel savedSock;
     private static final int fileSendingChunk = JMeterUtils.getPropDefault("kg.apc.jmeter.samplers.FileReadChunkSize", 1024 * 4);

--- a/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonCollector.java
+++ b/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonCollector.java
@@ -18,8 +18,8 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.vizualizers.CorrectedResultCollector;
@@ -33,7 +33,7 @@ public class JMXMonCollector
 
     private static final boolean autoGenerateFiles;
     private static final String JMXMON = "JmxMon";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JMXMonCollector.class);
     public static final String DATA_PROPERTY = "samplers";
     
     

--- a/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPool.java
+++ b/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonConnectionPool.java
@@ -12,8 +12,8 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * This class store jmx connections
@@ -26,7 +26,7 @@ public class JMXMonConnectionPool {
 	/**
 	 * the logger
 	 */
-	private static final Logger log = LoggingManager.getLoggerForClass();
+	private static final Logger log = LoggerFactory.getLogger(JMXMonConnectionPool.class);
 
 	/**
 	 * Store {@link JMXMonConnection}

--- a/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonSampler.java
+++ b/plugins/jmxmon/src/main/java/kg/apc/jmeter/jmxmon/JMXMonSampler.java
@@ -17,12 +17,12 @@ import javax.management.remote.JMXConnector;
 
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.threads.JMeterContextService;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class JMXMonSampler {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JMXMonSampler.class);
     private String metricName;
     private String objectName;
     private String attribute;

--- a/plugins/jmxmon/src/main/java/kg/apc/jmeter/vizualizers/JMXMonGui.java
+++ b/plugins/jmxmon/src/main/java/kg/apc/jmeter/vizualizers/JMXMonGui.java
@@ -17,13 +17,13 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class JMXMonGui
         extends AbstractOverTimeVisualizer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JMXMonGui.class);
     private PowerTableModel tableModel;
     private JTable grid;
     private JTextArea errorTextArea;

--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/YAMLToJSONConverter.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/YAMLToJSONConverter.java
@@ -2,14 +2,14 @@ package com.atlantbh.jmeter.plugins.jsonutils;
 
 
 import net.minidev.json.JSONObject;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.Map;
 
 public class YAMLToJSONConverter {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(YAMLToJSONConverter.class);
 
     public static String convert(String yamlString) {
         Yaml yaml = new Yaml();

--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatter.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatter.java
@@ -15,15 +15,15 @@ import net.sf.json.JsonConfig;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.threads.JMeterContext;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * This is main class for JSON formatter which contains formatJSON method that
  * takes sample result and do pretty print in JSON
  */
 public class JSONFormatter extends AbstractTestElement implements PostProcessor {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JSONFormatter.class);
     private static final long serialVersionUID = 1L;
     private static final JsonConfig config = new JsonConfig();
 

--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathassertion/JSONPathAssertion.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathassertion/JSONPathAssertion.java
@@ -17,8 +17,8 @@ import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.apache.oro.text.regex.Pattern;
 
 import java.io.Serializable;
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * previous sample result using JSON path expression
  */
 public class JSONPathAssertion extends AbstractTestElement implements Serializable, Assertion {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JSONPathAssertion.class);
     private static final long serialVersionUID = 1L;
     public static final String INPUT_JSON = "JSON";
     public static final String INPUT_YAML = "YAML";

--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathassertion/gui/JSONPathAssertionGui.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathassertion/gui/JSONPathAssertionGui.java
@@ -28,7 +28,7 @@ import java.util.Enumeration;
  */
 public class JSONPathAssertionGui extends AbstractAssertionGui implements ChangeListener {
 
-    //private static final Logger log = LoggingManager.getLoggerForClass();
+    //private static final Logger log = LoggerFactory.getLogger(JSONPathAssertionGui.class);
     private static final long serialVersionUID = 1L;
     private JLabeledTextField jsonPath = null;
     private JLabeledTextArea jsonValue = null;

--- a/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
+++ b/plugins/json/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonpathextractor/JSONPathExtractor.java
@@ -19,8 +19,8 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.text.DecimalFormat;
 import java.util.Map;
@@ -30,7 +30,7 @@ import java.util.Map;
  * result and extracts value from JSON output using JSONPath
  */
 public class JSONPathExtractor extends AbstractTestElement implements PostProcessor {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JSONPathExtractor.class);
 
     private static final long serialVersionUID = 1L;
 

--- a/plugins/lockfile/src/main/java/kg/apc/jmeter/config/LockFile.java
+++ b/plugins/lockfile/src/main/java/kg/apc/jmeter/config/LockFile.java
@@ -3,9 +3,9 @@ package kg.apc.jmeter.config;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.testelement.TestStateListener;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.util.JMeterStopTestNowException;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class LockFile extends ConfigTestElement
         implements TestStateListener {
 
-    public static Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LockFile.class);
     public static final String FILENAME = "filename";
     public static final String FILEMASK = "filemask";
 

--- a/plugins/lockfile/src/main/java/kg/apc/jmeter/config/LockFileGui.java
+++ b/plugins/lockfile/src/main/java/kg/apc/jmeter/config/LockFileGui.java
@@ -10,13 +10,13 @@ import javax.swing.JTextField;
 import kg.apc.jmeter.JMeterPluginsUtils;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LockFileGui extends AbstractConfigGui {
 
     public static final String WIKIPAGE = "LockFile";
-    public static Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LockFileGui.class);
     private JTextField tfFileName;
     private JTextField tfFileMask;
 

--- a/plugins/oauth/src/main/java/com/atlantbh/jmeter/plugins/oauth/OAuthSampler.java
+++ b/plugins/oauth/src/main/java/com/atlantbh/jmeter/plugins/oauth/OAuthSampler.java
@@ -16,9 +16,9 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler2;
 import org.apache.jmeter.protocol.http.util.HTTPConstantsInterface;
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +29,7 @@ import java.util.zip.GZIPInputStream;
 public class OAuthSampler extends HTTPSampler2 {
 
     private static final long serialVersionUID = -5877623539165274730L;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(OAuthSampler.class);
     public static final String CONSUMER_KEY = "OAuthSampler.consumer_key";
     public static final String CONSUMER_SECRET = "OAuthSampler.consumer_secret";
     public static final String REQUEST_BODY = "OAuthSampler.request_body";

--- a/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/NewAgentConnector.java
+++ b/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/NewAgentConnector.java
@@ -2,8 +2,8 @@ package kg.apc.jmeter.perfmon;
 
 import kg.apc.perfmon.PerfMonMetricGetter;
 import kg.apc.perfmon.client.Transport;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class NewAgentConnector implements PerfMonAgentConnector {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(NewAgentConnector.class);
     protected Transport transport;
     private Map<String, String> metrics = new HashMap<>();
     private String[] metricLabels;

--- a/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/PerfMonCollector.java
+++ b/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/PerfMonCollector.java
@@ -11,8 +11,8 @@ import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PerfMonCollector extends CorrectedResultCollector implements Runnable, PerfMonSampleGenerator {
     private static boolean autoGenerateFiles = false;
     private static final String PERFMON = "PerfMon";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PerfMonCollector.class);
     public static final String DATA_PROPERTY = "metricConnections";
     private int interval;
     private Thread workerThread = null;

--- a/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/UnavailableAgentConnector.java
+++ b/plugins/perfmon/src/main/java/kg/apc/jmeter/perfmon/UnavailableAgentConnector.java
@@ -1,15 +1,15 @@
 package kg.apc.jmeter.perfmon;
 
 import java.io.IOException;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * Using "null object" pattern
  */
 class UnavailableAgentConnector implements PerfMonAgentConnector {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(UnavailableAgentConnector.class);
     private IOException cause;
 
     UnavailableAgentConnector(IOException e) {

--- a/plugins/perfmon/src/main/java/kg/apc/jmeter/vizualizers/PerfMonGui.java
+++ b/plugins/perfmon/src/main/java/kg/apc/jmeter/vizualizers/PerfMonGui.java
@@ -43,14 +43,14 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class PerfMonGui
         extends AbstractOverTimeVisualizer {
 
     public static final List<String> metrics = Arrays.asList("CPU", "Memory", "Swap", "Disks I/O", "Network I/O");
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PerfMonGui.class);
     private PowerTableModel tableModel;
     private JTable grid;
     private JTextArea errorTextArea;

--- a/plugins/prmctl/src/main/java/kg/apc/jmeter/control/ParameterizedController.java
+++ b/plugins/prmctl/src/main/java/kg/apc/jmeter/control/ParameterizedController.java
@@ -7,15 +7,15 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
 public class ParameterizedController extends GenericController implements Serializable {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ParameterizedController.class);
 
     private void processVariables() {
         final Arguments args1 = (Arguments) this.getUserDefinedVariablesAsProperty().getObjectValue();

--- a/plugins/prmctl/src/main/java/kg/apc/jmeter/control/sampler/SetVariablesAction.java
+++ b/plugins/prmctl/src/main/java/kg/apc/jmeter/control/sampler/SetVariablesAction.java
@@ -8,14 +8,14 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Iterator;
 import java.util.Map;
 
 public class SetVariablesAction extends AbstractSampler {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SetVariablesAction.class);
 
     private void processVariables() {
         final Arguments args1 = (Arguments) this.getUserDefinedVariablesAsProperty().getObjectValue();

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
@@ -35,10 +35,10 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.util.JMeterStopThreadException;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
@@ -81,7 +81,7 @@ public class RedisDataSet extends ConfigTestElement
      */
     private static final long serialVersionUID = 7383500755324202605L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(RedisDataSet.class);
 
     public static final Integer DEFAULT_PORT = Protocol.DEFAULT_PORT;
     public static final Integer DEFAULT_TIMEOUT = Protocol.DEFAULT_TIMEOUT;

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSetBeanInfo.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSetBeanInfo.java
@@ -21,14 +21,14 @@ package kg.apc.jmeter.config.redis;
 import java.beans.PropertyDescriptor;
 
 import org.apache.jmeter.testbeans.BeanInfoSupport;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * BeanInfo for {@link RedisDataSet}
  */
 public class RedisDataSetBeanInfo extends BeanInfoSupport {
-    private static final Logger LOGGER = LoggingManager.getLoggerForClass();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisDataSetBeanInfo.class);
 
     // These names must agree case-wise with the variable and property names
     private static final String VARIABLE_NAMES = "variableNames";    

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
@@ -29,8 +29,8 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.timers.gui.AbstractTimerGui;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class VariableThroughputTimerGui
         extends AbstractTimerGui
@@ -38,7 +38,7 @@ public class VariableThroughputTimerGui
         CellEditorListener {
 
     public static final String WIKIPAGE = "ThroughputShapingTimer";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(VariableThroughputTimerGui.class);
     /**
      *
      */

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/functions/TSTFeedback.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/functions/TSTFeedback.java
@@ -8,15 +8,15 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 public class TSTFeedback extends AbstractFunction implements TestStateListener {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(TSTFeedback.class);
 
     private static final List<String> desc = new LinkedList<>();
     private static final String KEY = "__tstFeedback";

--- a/plugins/tst/src/test/java/kg/apc/jmeter/timers/functions/TSTFeedbackTest.java
+++ b/plugins/tst/src/test/java/kg/apc/jmeter/timers/functions/TSTFeedbackTest.java
@@ -4,8 +4,8 @@ import kg.apc.emulators.TestJMeterUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -17,7 +17,7 @@ import java.util.LinkedList;
 import static junit.framework.TestCase.assertEquals;
 
 public class TSTFeedbackTest {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(TSTFeedbackTest.class);
 
     @BeforeClass
     public static void setUpClass() {

--- a/plugins/udp/src/main/java/kg/apc/jmeter/samplers/DNSJavaTCPClientImpl.java
+++ b/plugins/udp/src/main/java/kg/apc/jmeter/samplers/DNSJavaTCPClientImpl.java
@@ -4,7 +4,8 @@ package kg.apc.jmeter.samplers;
 import kg.apc.io.BinaryUtils;
 import org.apache.jmeter.protocol.tcp.sampler.TCPClient;
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,7 +16,7 @@ import java.nio.charset.Charset;
 public class DNSJavaTCPClientImpl extends DNSJavaDecoder implements TCPClient {
 
     private ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    private static final org.apache.log.Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(DNSJavaTCPClientImpl.class);
 
     public void setupTest() {
     }

--- a/plugins/udp/src/main/java/kg/apc/jmeter/samplers/UDPSampler.java
+++ b/plugins/udp/src/main/java/kg/apc/jmeter/samplers/UDPSampler.java
@@ -3,8 +3,8 @@ package kg.apc.jmeter.samplers;
 import kg.apc.io.DatagramChannelWithTimeouts;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.ThreadListener;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,7 +16,7 @@ import java.nio.channels.spi.AbstractSelectableChannel;
 
 public class UDPSampler extends AbstractIPSampler implements UDPTrafficDecoder, ThreadListener {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(UDPSampler.class);
     public static final String ENCODECLASS = "encodeclass";
     public static final String WAITRESPONSE = "waitresponse";
     public static final String CLOSECHANNEL = "closechannel";

--- a/plugins/xml/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
+++ b/plugins/xml/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
@@ -21,8 +21,8 @@ import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.JMeterContext;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.w3c.dom.Document;
 
 /**
@@ -32,7 +32,7 @@ import org.w3c.dom.Document;
 public class XMLFormatPostProcessor extends AbstractTestElement implements
         Cloneable, Serializable, PostProcessor, TestElement {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(XMLFormatPostProcessor.class);
     private static final long serialVersionUID = -4885245911424989596L;
 
     public void process() {

--- a/tools/cmd/src/main/java/kg/apc/cmdtools/ReporterTool.java
+++ b/tools/cmd/src/main/java/kg/apc/cmdtools/ReporterTool.java
@@ -2,8 +2,8 @@ package kg.apc.cmdtools;
 
 import kg.apc.jmeter.PluginsCMDWorker;
 import kg.apc.logging.LoggingUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.apache.log.Priority;
 
 import java.io.PrintStream;
@@ -11,7 +11,7 @@ import java.util.ListIterator;
 
 public class ReporterTool extends AbstractCMDTool {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ReporterTool.class);
 
     static {
         LoggingUtils.addLoggingConfig();
@@ -52,15 +52,13 @@ public class ReporterTool extends AbstractCMDTool {
 
     @Override
     protected int processParams(ListIterator args) throws UnsupportedOperationException, IllegalArgumentException {
-        LoggingManager.setPriority(Priority.INFO);
         // first process params without worker created
         while (args.hasNext()) {
             String nextArg = (String) args.next();
             if (nextArg.equals("--loglevel")) {
                 args.remove();
-                String loglevelStr = (String) args.next();
+                args.next();
                 args.remove();
-                LoggingManager.setPriority(loglevelStr);
             }
         }
 

--- a/tools/cmd/src/main/java/kg/apc/jmeter/PluginsCMDWorker.java
+++ b/tools/cmd/src/main/java/kg/apc/jmeter/PluginsCMDWorker.java
@@ -5,8 +5,8 @@ import kg.apc.charting.GraphPanelChart;
 import kg.apc.cmd.UniversalRunner;
 import kg.apc.jmeter.graphs.AbstractGraphPanelVisualizer;
 import kg.apc.jmeter.vizualizers.CorrectedResultCollector;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,7 +26,7 @@ public class PluginsCMDWorker {
     private String outputCSV;
     private String outputPNG;
     private AbstractGraphPanelVisualizer pluginType;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PluginsCMDWorker.class);
     private int aggregate = -1;
     private int zeroing = -1;
     private int preventOutliers = -1;

--- a/tools/filterresults/src/main/java/kg/apc/cmdtools/FilterResultsTool.java
+++ b/tools/filterresults/src/main/java/kg/apc/cmdtools/FilterResultsTool.java
@@ -5,8 +5,8 @@ import kg.apc.jmeter.JMeterPluginsUtils;
 import kg.apc.jmeter.vizualizers.CorrectedResultCollector;
 import kg.apc.logging.LoggingUtils;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.apache.log.Priority;
 import org.jmeterplugins.tools.FilterResults;
 
@@ -15,7 +15,7 @@ import java.util.ListIterator;
 
 public class FilterResultsTool extends AbstractCMDTool {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FilterResultsTool.class);
 
     private FilterResults filterResults = null;
 
@@ -48,15 +48,13 @@ public class FilterResultsTool extends AbstractCMDTool {
 
         String outputFile = "out.res";
 
-        LoggingManager.setPriority(Priority.INFO);
         // first process params without worker created
         while (args.hasNext()) {
             String nextArg = (String) args.next();
             if (nextArg.equals("--loglevel")) {
                 args.remove();
-                String loglevelStr = (String) args.next();
+                args.next();
                 args.remove();
-                LoggingManager.setPriority(loglevelStr);
             }
         }
 

--- a/tools/filterresults/src/main/java/org/jmeterplugins/tools/FilterResults.java
+++ b/tools/filterresults/src/main/java/org/jmeterplugins/tools/FilterResults.java
@@ -11,8 +11,8 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.jmeterplugins.save.MergeResultsService;
 
 import kg.apc.jmeter.graphs.AbstractGraphPanelVisualizer;
@@ -25,7 +25,7 @@ import kg.apc.jmeter.vizualizers.JSettingsPanel;
 public class FilterResults extends AbstractGraphPanelVisualizer {
     private static final long serialVersionUID = 6432873068917332588L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(FilterResults.class);
     private Collection<String> emptyCollection = new ArrayList<String>();
 
     private List<SampleResult> samples = new ArrayList<SampleResult>();

--- a/tools/graphs-ggl/src/main/java/kg/apc/jmeter/listener/GraphsGeneratorListener.java
+++ b/tools/graphs-ggl/src/main/java/kg/apc/jmeter/listener/GraphsGeneratorListener.java
@@ -38,8 +38,8 @@ import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.visualizers.Visualizer;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * Listener that generates graphs
@@ -48,7 +48,7 @@ import org.apache.log.Logger;
 public class GraphsGeneratorListener extends AbstractListenerElement
     implements TestStateListener, TestBean, TestElement, Visualizer {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(GraphsGeneratorListener.class);
     
     private static final String PNG_SUFFIX = ".png"; 
     private static final String CSV_SUFFIX = ".csv"; 

--- a/tools/graphs-ggl/src/main/java/kg/apc/jmeter/listener/GraphsGeneratorListenerBeanInfo.java
+++ b/tools/graphs-ggl/src/main/java/kg/apc/jmeter/listener/GraphsGeneratorListenerBeanInfo.java
@@ -21,8 +21,8 @@ package kg.apc.jmeter.listener;
 import java.beans.PropertyDescriptor;
 
 import org.apache.jmeter.testbeans.BeanInfoSupport;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 /**
  * BeanInfo for {@link GraphsGeneratorListener}
@@ -31,7 +31,7 @@ import org.apache.log.Logger;
  */
 public class GraphsGeneratorListenerBeanInfo extends BeanInfoSupport {
 
-    private static final Logger LOGGER = LoggingManager.getLoggerForClass();
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphsGeneratorListenerBeanInfo.class);
     // These names must agree case-wise with the variable and property names
     private static final String OUTPUT_BASE_FOLDER = "outputBaseFolder";
     private static final String RESULTS_FILE_NAME = "resultsFileName";

--- a/tools/mergeresults/src/main/java/kg/apc/jmeter/vizualizers/MergeResultsGui.java
+++ b/tools/mergeresults/src/main/java/kg/apc/jmeter/vizualizers/MergeResultsGui.java
@@ -66,8 +66,8 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.ComponentUtil;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.jmeterplugins.save.MergeResultsService;
 
 public class MergeResultsGui extends AbstractGraphPanelVisualizer implements
@@ -75,7 +75,7 @@ public class MergeResultsGui extends AbstractGraphPanelVisualizer implements
 
     private static final long serialVersionUID = 240L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(MergeResultsGui.class);
 
     public static final String WIKIPAGE = "MergeResults";
 

--- a/tools/mergeresults/src/main/java/org/jmeterplugins/save/MergeResultsService.java
+++ b/tools/mergeresults/src/main/java/org/jmeterplugins/save/MergeResultsService.java
@@ -38,12 +38,12 @@ import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.save.SaveService;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class MergeResultsService {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(MergeResultsService.class);
 
     private static final String TESTRESULTS_START_V1_1_PREVER = "<testResults version=\""; 
 

--- a/tools/pde/src/main/java/kg/apc/jmeter/vizualizers/PageDataExtractorOverTimeGui.java
+++ b/tools/pde/src/main/java/kg/apc/jmeter/vizualizers/PageDataExtractorOverTimeGui.java
@@ -29,14 +29,14 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 
 public class PageDataExtractorOverTimeGui extends AbstractOverTimeVisualizer implements CMDLineArgumentsProcessor {
 
     private static final String REGEXPS_PROPERTY = "regexps";
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PageDataExtractorOverTimeGui.class);
     private PowerTableModel tableModel;
     private JTable grid;
     public static final String[] columnIdentifiers = new String[]{

--- a/tools/plancheck/src/main/java/kg/apc/cmdtools/TestPlanCheckTool.java
+++ b/tools/plancheck/src/main/java/kg/apc/cmdtools/TestPlanCheckTool.java
@@ -22,8 +22,8 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.timers.Timer;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.HashTreeTraverser;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.apache.log.Priority;
 
 import java.io.File;
@@ -33,7 +33,7 @@ import java.util.ListIterator;
 
 public class TestPlanCheckTool extends AbstractCMDTool {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(TestPlanCheckTool.class);
     private String jmx = null;
 
     public TestPlanCheckTool() {
@@ -57,15 +57,13 @@ public class TestPlanCheckTool extends AbstractCMDTool {
     @Override
     protected int processParams(ListIterator args) throws UnsupportedOperationException, IllegalArgumentException {
         // TODO: extract this duplicated code
-        LoggingManager.setPriority(Priority.INFO);
         // first process params without worker created
         while (args.hasNext()) {
             String nextArg = (String) args.next();
             if (nextArg.equals("--loglevel")) {
                 args.remove();
-                String loglevelStr = (String) args.next();
+                args.next();
                 args.remove();
-                LoggingManager.setPriority(loglevelStr);
             }
         }
 

--- a/tools/synthesis/src/main/java/kg/apc/jmeter/vizualizers/AggregateReportGui.java
+++ b/tools/synthesis/src/main/java/kg/apc/jmeter/vizualizers/AggregateReportGui.java
@@ -28,9 +28,9 @@ import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.RateRenderer;
 import org.apache.jorphan.gui.RendererUtils;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.reflect.Functor;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 
 /**
  * OMG, I had to copy full contents of StatVisualizer just to make its data
@@ -41,7 +41,7 @@ public class AggregateReportGui extends AbstractGraphPanelVisualizer {
 
     private Collection<String> emptyCollection = new ArrayList<>();
     private static final long serialVersionUID = 241L;
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AggregateReportGui.class);
     private static final String USE_GROUP_NAME = "useGroupName";
     private static final String SAVE_HEADERS = "saveHeaders";
     private static final String[] COLUMNS = {

--- a/tools/synthesis/src/main/java/kg/apc/jmeter/vizualizers/SynthesisReportGui.java
+++ b/tools/synthesis/src/main/java/kg/apc/jmeter/vizualizers/SynthesisReportGui.java
@@ -34,10 +34,10 @@ import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.RateRenderer;
 import org.apache.jorphan.gui.RendererUtils;
-import org.apache.jorphan.logging.LoggingManager;
+import org.slf4j.LoggerFactory;
 import org.apache.jorphan.reflect.Functor;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 import org.jmeterplugins.visualizers.gui.FilterPanel;
 
 import javax.swing.*;
@@ -77,7 +77,7 @@ public class SynthesisReportGui extends AbstractGraphPanelVisualizer implements
 
     protected FilterPanel jPanelFilter;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(SynthesisReportGui.class);
 
     public static final String WIKIPAGE = "SynthesisReport";
 

--- a/tools/table-server/src/main/java/org/jmeterplugins/protocol/http/control/gui/HttpSimpleTableControlGui.java
+++ b/tools/table-server/src/main/java/org/jmeterplugins/protocol/http/control/gui/HttpSimpleTableControlGui.java
@@ -42,8 +42,8 @@ import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.jmeterplugins.protocol.http.control.HttpSimpleTableControl;
 
 public class HttpSimpleTableControlGui extends LogicControllerGui implements
@@ -51,7 +51,7 @@ public class HttpSimpleTableControlGui extends LogicControllerGui implements
 
     private static final long serialVersionUID = 240L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(HttpSimpleTableControlGui.class);
 
     public static final String WIKIPAGE = "HttpSimpleTableServer";
 

--- a/tools/table-server/src/main/resources/org/jmeterplugins/protocol/http/control/simple-table-server.bsh
+++ b/tools/table-server/src/main/resources/org/jmeterplugins/protocol/http/control/simple-table-server.bsh
@@ -2,11 +2,11 @@ print("Startup beanshell script running");
 
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JMeterException;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.reflect.ClassTools;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-private static final Logger log = LoggingManager.getLoggerForClass();
+private static final Logger log = LoggerFactory.getLogger("bsh.startup");
 
 int simpleTablePort = JMeterUtils.getPropDefault(
         "jmeterPlugin.sts.port", 0);

--- a/tools/table-server/src/test/java/org/jmeterplugins/protocol/http/control/HttpSimpleTableServerEmul.java
+++ b/tools/table-server/src/test/java/org/jmeterplugins/protocol/http/control/HttpSimpleTableServerEmul.java
@@ -1,13 +1,13 @@
 package org.jmeterplugins.protocol.http.control;
 
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 
 
 class HttpSimpleTableServerEmul extends HttpSimpleTableServer {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(HttpSimpleTableServerEmul.class);
 
     @Override
     public void start() throws IOException {


### PR DESCRIPTION
With JMeter 5.4 we want(ed) to drop the deprecated LoggingManager and `org.apache.log.Logger` classes. While testing the release, we found, that jmeter-plugins still rely on those classes and will break startup of JMeter (that is another bug :) but inside of JMeter).
This PR tries to remove all occurrences of LogginManager and org.apache.log.Logger and replaces those by loggers from SLF4J (which is used by JMeter currently).

**Breaking Changes**

Most of the classes used the loggers as private instance or class variables and should be OK to be changed. However there are a few classes, that expose the old Logger class by storing those in protected or public class variables. This PR changes that! The loggers are made private to hopefully help future developers and change the implementations to SLF4J.