### PR TITLE
Add HLS Release v3.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -585,6 +585,24 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.1": {
+        "changes": "Improved protocol recognition and fixed minor dash issues",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jmeter-bzm-hls-3.1.jar",
+        "libs": {
+          "hlsparserj>=1.0.1-c287e78": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/hlsparserj-c287e78.jar",
+          "mpd-parser>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/mpd-parser-0.8-jdk8.jar",
+          "jackson-core>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-core-2.10.2.jar",
+          "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-dataformat-xml-2.10.2.jar",
+          "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-annotations-2.10.2.jar",
+          "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-databind-2.10.2.jar",
+          "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-module-jaxb-annotations-2.10.2.jar",
+          "stax2-api>=4.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/stax2-api-4.2.jar",
+          "woodstox-core>=5.3.0":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/woodstox-core-5.3.0.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
Now is possible to manually specify in sampler what is the protocol to be used while downloading the playlist!
By default, the sampler can automatically detect the protocol, but in some corner cases, the detection logic can't properly identify the protocol. In such scenarios, you can now manually specify which is the correct protocol.

Fix segment URL resolution for DASH live streamings which were previously generating incorrect timestamp values.