### PR TITLE
Addition of a new Apdex Calculator plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -911,7 +911,7 @@
 			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.2/jmeter-plugins-outlierdetector-1.0.2.jar",
 			"depends": [
 				"jmeter-core"
-				],
+			],
 			"libs": {
 				"jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
 			}
@@ -921,14 +921,15 @@
 			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.1/jmeter-plugins-outlierdetector-1.0.1.jar",
 			"depends": [
 				"jmeter-core"
-				]
-			},
+			]
+		},
 		"1.0.0": {
             "changes": "Initial version.",
 			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/v1.0.0/jmeter-plugins-outlierdetector-1.0.jar",
 			"depends": [
 				"jmeter-core"
-				]
+			]
 		}    
 	}
+  }
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -892,5 +892,26 @@
         ]
       }
     }
+  },
+  {
+    "id": "outlierdetector",
+    "name": "Right Tail Outlier Detector",
+    "description": "A Jmeter plugin that detects and removes outliers in the right tail using Tukey fences.",
+    "screenshotUrl": "https://github.com/rbourga/jmeter-plugins-2/blob/main/tools/outlierdetector/src/site/img/wiki/rtod_Principle.jpg",
+    "helpUrl": "https://github.com/rbourga/jmeter-plugins-2/blob/main/tools/outlierdetector/src/site/dat/wiki/RightTailOutlierDetection.wiki",
+    "vendor": "Robert Bourgault du Coudray",
+    "markerClass": "kg.apc.jmeter.vizualizers.RightTailOutlierDetectorGui",
+    "componentClasses": [
+      "kg.apc.jmeter.vizualizers.RightTailOutlierDetectorGui",
+      "kg.apc.cmdtools.RightTailOutlierDetectorTool"
+    ],
+    "versions": {
+      "1.0.0": {
+        "downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/v1.0.0/jmeter-plugins-outlierdetector-1.0.jar",
+        "depends": [
+          "jmeter-core"
+        ]
+      }
+    }    
   }
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -906,15 +906,15 @@
       "kg.apc.cmdtools.RightTailOutlierDetectorTool"
     ],
     "versions": {
-      "1.0.2": {
-        "changes": "Changed Java compliance level to 1.8.",
-        "downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.2/jmeter-plugins-outlierdetector-1.0.2.jar",
-        "depends": [
-          "jmeter-core"
-        ],
-        "libs": {
-          "jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
-          }
+		"1.0.2": {
+			"changes": "Changed Java compliance level to 1.8.",
+			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.2/jmeter-plugins-outlierdetector-1.0.2.jar",
+			"depends": [
+				"jmeter-core"
+				],
+			"libs": {
+				"jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
+			}
         },
 		"1.0.1": {
 			"changes": "Fix of HelpLink and of jar version number",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -906,12 +906,20 @@
       "kg.apc.cmdtools.RightTailOutlierDetectorTool"
     ],
     "versions": {
-      "1.0.0": {
-        "downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/v1.0.0/jmeter-plugins-outlierdetector-1.0.jar",
-        "depends": [
-          "jmeter-core"
-        ]
-      }
-    }    
-  }
+		"1.0.1": {
+			"changes": "Fix of HelpLink and of jar version number",
+			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.1/jmeter-plugins-outlierdetector-1.0.1.jar",
+			"depends": [
+				"jmeter-core"
+				]
+			},
+		"1.0.0": {
+            "changes": "Initial version.",
+			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/v1.0.0/jmeter-plugins-outlierdetector-1.0.jar",
+			"depends": [
+				"jmeter-core"
+				]
+			}
+		}    
+	}
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -906,6 +906,16 @@
       "kg.apc.cmdtools.RightTailOutlierDetectorTool"
     ],
     "versions": {
+      "1.0.2": {
+        "changes": "Changed Java compliance level to 1.8.",
+        "downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.2/jmeter-plugins-outlierdetector-1.0.2.jar",
+        "depends": [
+          "jmeter-core"
+        ],
+        "libs": {
+          "jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
+          }
+        },
 		"1.0.1": {
 			"changes": "Fix of HelpLink and of jar version number",
 			"downloadUrl": "https://github.com/rbourga/jmeter-plugins-2/releases/download/V1.0.1/jmeter-plugins-outlierdetector-1.0.1.jar",
@@ -919,7 +929,7 @@
 			"depends": [
 				"jmeter-core"
 				]
-			}
+			}			
 		}    
 	}
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -973,6 +973,30 @@
     }
   },
   {
+  	"id" : "apdexcalculator",
+    "name" : "Apdex Score Calculator",
+    "description" : "Calculates the Apdex score and rating of Samplers for a given satisfied threshold.",
+    "screenshotUrl" : "https://github.com/rbourga/jmeter-plugins-2/blob/main/tools/apdexcalculator/src/site/img/wiki/apdex_Calculate.PNG",
+    "helpUrl": "https://github.com/rbourga/jmeter-plugins-2/blob/main/tools/apdexcalculator/src/site/dat/wiki/ApdexScoreCalculator.wiki",
+    "vendor": "Robert Bourgault du Coudray",
+    "markerClass": "kg.apc.jmeter.vizualisers.ApdexScoreCalculatorGui",
+    "componentClasses": [
+      "kg.apc.jmeter.vizualizers.ApdexScoreCalculatorGui",
+      "kg.apc.cmdtools.ApdexScoreCalculatorTool"
+    ],
+    "versions" : {
+    	"1.0.1" : {
+    		"downloadUrl" : "https://github.com/rbourga/jmeter-plugins-2/releases/download/V2.0.0/jmeter-plugins-apdexcalculator-1.0.1.jar",
+            "libs" : {
+            	"jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
+            },
+            "depends" : [
+				"jmeter-core"
+            ]
+        }
+    }
+  },
+  {
     "id": "outlierdetector",
     "name": "Right Tail Outlier Detector",
     "description": "A Jmeter plugin that detects and removes outliers in the right tail using Tukey fences.",
@@ -1010,8 +1034,6 @@
 			]
 		}    
 	}
-<<<<<<< HEAD
-=======
   },
   {
     "id": "awsmeter",
@@ -1096,6 +1118,5 @@
         ]
       }
     }
->>>>>>> upstream/master
   }
 ]

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -273,6 +273,15 @@
           "jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar",
           "jsch": "https://search.maven.org/remotecontent?filepath=com/jcraft/jsch/0.1.54/jsch-0.1.54.jar"
         }
+      },
+      "1.3": {
+        "changes": "<ul><li>Replaced ssh client library <a href=\"http://www.jcraft.com/jsch/\">JSch</a> with <a href=\"https://mina.apache.org/sshd-project/\">Apache Mina SSHD</a></li><li>ProxyJump support</li><li>Bug fixes</li></ul>",
+        "downloadUrl": "https://github.com/tilln/jmeter-sshmon/releases/download/1.3/jmeter-sshmon-1.3.jar",
+        "libs": {
+          "jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar",
+          "sshd-core>=2.6": "https://search.maven.org/remotecontent?filepath=org/apache/sshd/sshd-core/2.6.0/sshd-core-2.6.0.jar",
+          "sshd-common>=2.6": "https://search.maven.org/remotecontent?filepath=org/apache/sshd/sshd-common/2.6.0/sshd-common-2.6.0.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
This plugin parses a JMeter results file and computes the Apdex score and rating of the samplers for a given satisfied threshold T, as per Apdex specs. No need to generate the Report Dash Board to get Apdex value!
As per Apdex specs, rating goes from "Unacceptable" to "Excellent", which should help in the decision of the test conclusion.