### PR TITLE
Release v1.2 Correlation Recorder

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -993,17 +993,17 @@
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-databind-2.10.2.jar",
           "jackson-core>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-core-2.10.2.jar",
           "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-module-jaxb-annotations-2.10.2.jar"
-        },
-        "1.2": {
-          "changes": "Added Groups of Correlation Rules",
-          "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jmeter-bzm-correlation-recorder-1.2.jar",
-          "libs": {
-            "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-dataformat-xml-2.10.2.jar",
-            "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-annotations-2.10.2.jar",
-            "jackson-databind>=2.12.0" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-databind-2.12.0.jar",
-            "jackson-core>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-core-2.10.2.jar",
-            "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-module-jaxb-annotations-2.10.2.jar"
-          }
+        }
+      },
+      "1.2": {
+        "changes": "Added Groups of Correlation Rules",
+        "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jmeter-bzm-correlation-recorder-1.2.jar",
+        "libs": {
+          "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-dataformat-xml-2.10.2.jar",
+          "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-annotations-2.10.2.jar",
+          "jackson-databind>=2.12.0" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-databind-2.12.0.jar",
+          "jackson-core>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-core-2.10.2.jar",
+          "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-module-jaxb-annotations-2.10.2.jar"
         }
       }
     }

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -993,6 +993,17 @@
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-databind-2.10.2.jar",
           "jackson-core>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-core-2.10.2.jar",
           "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.1.2/jackson-module-jaxb-annotations-2.10.2.jar"
+        },
+        "1.2": {
+          "changes": "Added Groups of Correlation Rules",
+          "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jmeter-bzm-correlation-recorder-1.2.jar",
+          "libs": {
+            "jackson-dataformat-xml>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-dataformat-xml-2.10.2.jar",
+            "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-annotations-2.10.2.jar",
+            "jackson-databind>=2.12.0" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-databind-2.12.0.jar",
+            "jackson-core>=2.10.2" : "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-core-2.10.2.jar",
+            "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/CorrelationRecorder/releases/download/v1.2/jackson-module-jaxb-annotations-2.10.2.jar"
+          }
         }
       }
     }


### PR DESCRIPTION
Now is possible to separate your Correlation Rules into groups improving your testing capabilities:

Having a different set of rules separated into groups ease the testing due to the possibility of enabling and disabling them in bulk (applying its effect to the rules each contains)
Each group is self-managed, allowing to add, delete, disable and edit a set of rules without altering the rest of the correlations.
Other changes:

Now each Correlation Extractor/Replacement hide by default its advanced fields, displaying only the most used ones for a faster setup.
Improved the addition of custom extensions to your environment, by selecting "More" on each combo, a dialogue will allow you to interactively choose which extension want to use or remove.