### PR TITLE
RTE Plugin release v3.2

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -930,6 +930,15 @@
           "dm3270-lib>=0.12.4": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1.1/dm3270-lib-0.12.4.jar",
           "jVT220>=1.3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.1.1/jVT220-1.3.1.jar"
         }
+      },
+      "3.2": {
+        "changes": "Wait for disconnect support in RTESampler and automatic detection by RTERecorder",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2/jmeter-bzm-rte-3.2.jar",
+        "libs": {
+          "xtn5250>=3.2.3": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2/xtn5250-3.2.3.jar",
+          "dm3270-lib>=0.13": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2/dm3270-lib-0.13.jar",
+          "jVT220>=1.3.1": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2/jVT220-1.3.1.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
What's new on this minor release

- Wait for disconnect support. 
   - Now is possible to assert when a server disconnection occurs.
   > E.g: Makes possible to validate the behave of a LOGOFF command.
- Automatic *Wait for Disconnect* recognition.
  - When using the **Recorder** the **Terminal Emulator** will automatically detect for a server disconnection. Therefore a Wait for Disconnect is recorded and added to the current sampler.
- We have also fixed some issues:
  - Frozen screen when recording TN3270 protocol.
  - Not possible to send spaces as input.