### PR TITLE
Support redis ssl connections

### DIFF
--- a/plugins/redis/pom.xml
+++ b/plugins/redis/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-redis</artifactId>
-    <version>0.3</version>
+    <version>0.4</version>
 
     <name>Redis</name>
     <description>Redis</description>
@@ -62,12 +62,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-            <version>1.6</version>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>com.io7m.xom</groupId>

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
@@ -23,7 +23,7 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.util.ResourceBundle;
 
-import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
@@ -52,20 +52,6 @@ import redis.clients.jedis.exceptions.JedisDataException;
  */
 public class RedisDataSet extends ConfigTestElement 
     implements TestBean, LoopIterationListener, NoConfigMerge, TestStateListener {
-    public enum WhenExhaustedAction {
-        FAIL(GenericObjectPool.WHEN_EXHAUSTED_FAIL),
-        BLOCK(GenericObjectPool.WHEN_EXHAUSTED_BLOCK),
-        GROW(GenericObjectPool.WHEN_EXHAUSTED_GROW);
-        
-        private byte value;
-        private WhenExhaustedAction(byte value) {
-            this.value = value;
-        }
-        
-        public byte getValue() {
-            return value;
-        }
-    }
 
     public enum RedisDataType {
         REDIS_DATA_TYPE_LIST((byte)0),
@@ -86,10 +72,14 @@ public class RedisDataSet extends ConfigTestElement
     public static final Integer DEFAULT_PORT = Protocol.DEFAULT_PORT;
     public static final Integer DEFAULT_TIMEOUT = Protocol.DEFAULT_TIMEOUT;
     public static final Integer DEFAULT_DATABASE = Protocol.DEFAULT_DATABASE;
+    public static final Integer DEFAULT_MAX_ACTIVE = GenericObjectPoolConfig.DEFAULT_MAX_TOTAL;
+    public static final Integer DEFAULT_MAX_IDLE = GenericObjectPoolConfig.DEFAULT_MAX_IDLE;
+    public static final Integer DEFAULT_MIN_IDLE = GenericObjectPoolConfig.DEFAULT_MIN_IDLE;
 
     /* Connection configuration */
     private String host = "localhost";
     private String port = String.valueOf(DEFAULT_PORT);
+    private boolean ssl = false;
     private String timeout = String.valueOf(DEFAULT_TIMEOUT);
     private String password;
     private String database = String.valueOf(DEFAULT_DATABASE);
@@ -102,11 +92,11 @@ public class RedisDataSet extends ConfigTestElement
     private RedisDataType redisDataType = RedisDataType.REDIS_DATA_TYPE_LIST;
 
     /* Pool configuration */
-    private int maxIdle;
-    private int minIdle;
-    private int maxActive;
+    private int maxIdle = DEFAULT_MAX_IDLE;
+    private int minIdle = DEFAULT_MIN_IDLE;
+    private int maxActive = DEFAULT_MAX_ACTIVE;
     private long maxWait;
-    private WhenExhaustedAction whenExhaustedAction = WhenExhaustedAction.GROW;
+    private boolean blockWhenExhausted;
     private boolean testOnBorrow;
     private boolean testOnReturn;
     private boolean testWhileIdle;
@@ -226,27 +216,7 @@ public class RedisDataSet extends ConfigTestElement
     public void setProperty(JMeterProperty property) {
         if (property instanceof StringProperty) {
             final String pn = property.getName();
-            if (pn.equals("whenExhaustedAction")) {
-                final Object objectValue = property.getObjectValue();
-                try {
-                    final BeanInfo beanInfo = Introspector.getBeanInfo(this.getClass());
-                    final ResourceBundle rb = (ResourceBundle) beanInfo.getBeanDescriptor().getValue(GenericTestBeanCustomizer.RESOURCE_BUNDLE);
-                    for(Enum<WhenExhaustedAction> e : WhenExhaustedAction.values()) {
-                        final String propName = e.toString();
-                        if (objectValue.equals(rb.getObject(propName))) {
-                            final int tmpMode = e.ordinal();
-                            if (log.isDebugEnabled()) {
-                                log.debug("Converted " + pn + "=" + objectValue + " to mode=" + tmpMode  + " using Locale: " + rb.getLocale());
-                            }
-                            super.setProperty(pn, tmpMode);
-                            return;
-                        }
-                    }
-                    log.warn("Could not convert " + pn + "=" + objectValue + " using Locale: " + rb.getLocale());
-                } catch (IntrospectionException e) {
-                    log.error("Could not find BeanInfo", e);
-                }
-            } else if (pn.equals("redisDataType")) {
+            if (pn.equals("redisDataType")) {
                 final Object objectValue = property.getObjectValue();
                 try {
                     final BeanInfo beanInfo = Introspector.getBeanInfo(this.getClass());
@@ -274,11 +244,11 @@ public class RedisDataSet extends ConfigTestElement
     @Override
     public void testStarted(String distributedHost) {
         JedisPoolConfig config = new JedisPoolConfig();
-        config.setMaxActive(getMaxActive());
+        config.setMaxTotal(getMaxActive());
         config.setMaxIdle(getMaxIdle());
         config.setMinIdle(getMinIdle());
-        config.setMaxWait(getMaxWait());
-        config.setWhenExhaustedAction((byte)getWhenExhaustedAction());
+        config.setMaxWaitMillis(getMaxWait());
+        config.setBlockWhenExhausted(getBlockWhenExhausted());
         config.setTestOnBorrow(getTestOnBorrow());
         config.setTestOnReturn(getTestOnReturn());
         config.setTestWhileIdle(getTestWhileIdle());
@@ -332,6 +302,20 @@ public class RedisDataSet extends ConfigTestElement
      */
     public void setPort(String port) {
         this.port = port;
+    }
+
+    /**
+     * @return the ssl
+     */
+    public boolean getSsl() {
+        return ssl;
+    }
+
+    /**
+     * @param ssl the ssl to set
+     */
+    public void setSsl(boolean ssl) {
+        this.ssl = ssl;
     }
 
     /**
@@ -475,17 +459,17 @@ public class RedisDataSet extends ConfigTestElement
     }
 
     /**
-     * @return the whenExhaustedAction
+     * @return the blockWhenExhausted
      */
-    public int getWhenExhaustedAction() {
-        return whenExhaustedAction.ordinal();
+    public boolean getBlockWhenExhausted() {
+        return blockWhenExhausted;
     }
 
     /**
-     * @param whenExhaustedAction the whenExhaustedAction to set
+     * @param blockWhenExhausted the blockWhenExhausted to set
      */
-    public void setWhenExhaustedAction(int whenExhaustedAction) {
-        this.whenExhaustedAction = WhenExhaustedAction.values()[whenExhaustedAction];
+    public void setBlockWhenExhausted(boolean blockWhenExhausted) {
+        this.blockWhenExhausted = blockWhenExhausted;
     }
 
     /**

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSetBeanInfo.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSetBeanInfo.java
@@ -38,6 +38,7 @@ public class RedisDataSetBeanInfo extends BeanInfoSupport {
     private static final String RECYCLE_DATA_ON_USE = "recycleDataOnUse";  //$NON-NLS-1$
     private static final String HOST = "host";             
     private static final String PORT = "port";             
+    private static final String SSL = "ssl";
     private static final String TIMEOUT = "timeout";             
     private static final String PASSWORD = "password";             
     private static final String DATABASE = "database";             
@@ -46,7 +47,7 @@ public class RedisDataSetBeanInfo extends BeanInfoSupport {
     private static final String MAX_IDLE = "maxIdle";                 
     private static final String MAX_WAIT = "maxWait";                 
     private static final String MIN_IDLE = "minIdle";                 
-    private static final String WHEN_EXHAUSTED_ACTION = "whenExhaustedAction";                 
+    private static final String BLOCK_WHEN_EXHAUSTED = "blockWhenExhausted";
     private static final String TEST_WHILE_IDLE = "testWhileIdle";                 
     private static final String TEST_ON_BORROW = "testOnBorrow";                 
     private static final String TEST_ON_RETURN = "testOnReturn";                 
@@ -113,6 +114,12 @@ public class RedisDataSetBeanInfo extends BeanInfoSupport {
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);
             p.setValue(DEFAULT, RedisDataSet.DEFAULT_PORT);
             p.setValue(NOT_EXPRESSION, Boolean.TRUE);
+
+            p = property(SSL);
+            p.setValue(NOT_UNDEFINED, Boolean.TRUE);
+            p.setValue(DEFAULT, Boolean.FALSE);
+            p.setValue(NOT_EXPRESSION, Boolean.TRUE);
+            p.setValue(NOT_OTHER, Boolean.TRUE);
     
             p = property(TIMEOUT);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);
@@ -131,24 +138,24 @@ public class RedisDataSetBeanInfo extends BeanInfoSupport {
             
             
             createPropertyGroup("pool_config",             
-                    new String[] { MIN_IDLE, MAX_IDLE, MAX_ACTIVE, MAX_WAIT, WHEN_EXHAUSTED_ACTION,
+                    new String[] { MIN_IDLE, MAX_IDLE, MAX_ACTIVE, MAX_WAIT, BLOCK_WHEN_EXHAUSTED,
                         TEST_ON_BORROW, TEST_ON_RETURN, TEST_WHILE_IDLE, TIME_BETWEEN_EVICTION_RUNS_MS,
                         NUM_TEST_PER_EVICTION_RUN, MIN_EVICTABLE_IDLE_TIME_MS, SOFT_MIN_EVICTABLE_IDLE_TIME_MS});
             
             
             p = property(MIN_IDLE);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);
-            p.setValue(DEFAULT, "0");        
+            p.setValue(DEFAULT, RedisDataSet.DEFAULT_MIN_IDLE);
             p.setValue(NOT_EXPRESSION, Boolean.TRUE);
             
             p = property(MAX_IDLE);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);
-            p.setValue(DEFAULT, "10");        
+            p.setValue(DEFAULT, RedisDataSet.DEFAULT_MAX_IDLE);
             p.setValue(NOT_EXPRESSION, Boolean.TRUE);
     
             p = property(MAX_ACTIVE);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);
-            p.setValue(DEFAULT, "20");        
+            p.setValue(DEFAULT, RedisDataSet.DEFAULT_MAX_ACTIVE);
             p.setValue(NOT_EXPRESSION, Boolean.TRUE);
     
             p = property(MAX_WAIT);
@@ -156,9 +163,11 @@ public class RedisDataSetBeanInfo extends BeanInfoSupport {
             p.setValue(DEFAULT, "30000");        
             p.setValue(NOT_EXPRESSION, Boolean.TRUE);
     
-            p = property(WHEN_EXHAUSTED_ACTION, RedisDataSet.WhenExhaustedAction.class); 
-            p.setValue(DEFAULT, RedisDataSet.WhenExhaustedAction.GROW.ordinal());
+            p = property(BLOCK_WHEN_EXHAUSTED);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE); // must be defined
+            p.setValue(DEFAULT, Boolean.FALSE);
+            p.setValue(NOT_EXPRESSION, Boolean.TRUE);
+            p.setValue(NOT_OTHER, Boolean.TRUE);
             
             p = property(TEST_ON_BORROW);
             p.setValue(NOT_UNDEFINED, Boolean.TRUE);

--- a/plugins/redis/src/main/resources/kg/apc/jmeter/config/redis/RedisDataSetResources.properties
+++ b/plugins/redis/src/main/resources/kg/apc/jmeter/config/redis/RedisDataSetResources.properties
@@ -35,16 +35,14 @@ host.shortDescription=Redis server host
 
 port.displayName=Redis server port
 port.shortDescription=Redis server port (defaults to 6379)
+ssl.displayName=SSL/TLS
+ssl.shortDescription=Connect via SSL/TLS
 timeout.displayName=Timeout for connection in ms
 timeout.shortDescription=Defaults to 2000 ms
 password.displayName=Password for connection
 password.shortDescription=Defaults to null
 database.displayName=Database
 database.shortDescription=Defaults to 0
-
-FAIL=FAIL
-BLOCK=BLOCK
-GROW=GROW
 
 REDIS_DATA_TYPE_LIST=List
 REDIS_DATA_TYPE_SET=Set


### PR DESCRIPTION
* bump jedis dependency to latest 3.x version which has ssl support
* expose boolean config for ssl connection
* This has a knock-on effect of changing the commons-pool dependency from commons-pool 1 to commons-pool 2
* this has a knock-on effect of changing the configuration for what to do when the pool is exhausted. `maxActive` was removed and it appears that `maxTotal` is its replacement.

unfortunately I haven't been able to add test coverage because i can't find a mock redis library for java that supports ssl