### PR TITLE
New version of ResultsComparator plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1081,7 +1081,7 @@
     "versions" : {
     	"2.1" : {
 			"changes": "Addition of Pass/Fail testing criteria.",
-    		"downloadUrl" : "https://github.com/rbourga/jmeter-plugins-2/releases/download/v3.1.0/jmeter-plugins-resultscomparator-2.1.jar,
+    		"downloadUrl" : "https://github.com/rbourga/jmeter-plugins-2/releases/download/v3.1.0/jmeter-plugins-resultscomparator-2.1.jar",
             "libs" : {
             	"jmeter-plugins-cmn-jmeter>=0.6": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.6/jmeter-plugins-cmn-jmeter-0.6.jar"
             },


### PR DESCRIPTION
Addition of a Pass/Fail criteria for comparing a test run against a baseline.
User can now set a threshold for Cohen's d and all samplers having their d above this threshold will be marked as "failed", meaning that there is a too big degradation in the response times. 