### PR TITLE
Added support for identifier property for FreeFormArrivalsThreadGroup

### DIFF
--- a/plugins/casutg/pom.xml
+++ b/plugins/casutg/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-casutg</artifactId>
-    <version>2.10</version>
+    <version>2.11</version>
 
     <name>Custom Thread Groups</name>
     <description>Custom Thread Groups</description>

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AdditionalFieldsPanel.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AdditionalFieldsPanel.java
@@ -13,11 +13,14 @@ public class AdditionalFieldsPanel extends ArrangedLabelFieldPanel implements Pa
     protected JTextField logFile = new JTextField();
     protected JTextField iterations = new JTextField();
     protected JTextField concurrLimit = new JTextField();
+    protected JTextField propertiesIdentifier = new JTextField();
     protected ButtonGroup unitGroup = new ButtonGroup();
     protected JRadioButton unitSeconds = new JRadioButton("seconds");
     protected JRadioButton unitMinutes = new JRadioButton("minutes");
+    protected JCheckBox useIdentifier = new JCheckBox("useIdentifier");
+    protected boolean showIdentifier;
 
-    public AdditionalFieldsPanel(boolean showConcurrencyLimit) {
+    public AdditionalFieldsPanel(boolean showConcurrencyLimit, boolean showIdentifier) {
         JPanel groupPanel = new HorizontalPanel();
         unitMinutes.setActionCommand(ArrivalsThreadGroup.UNIT_MINUTES);
         unitSeconds.setActionCommand(ArrivalsThreadGroup.UNIT_SECONDS);
@@ -27,8 +30,15 @@ public class AdditionalFieldsPanel extends ArrangedLabelFieldPanel implements Pa
         groupPanel.add(unitSeconds);
         add("Time Unit: ", groupPanel);
 
+
         add("Thread Iterations Limit: ", iterations);
+
         add("Log Threads Status into File: ", logFile);
+        this.showIdentifier = showIdentifier;
+        if (this.showIdentifier) {
+            add("Load from Properties", useIdentifier);
+            add("Properties identifier:", propertiesIdentifier);
+        }
 
         if (showConcurrencyLimit) {
             add("Concurrency Limit: ", concurrLimit);
@@ -39,6 +49,10 @@ public class AdditionalFieldsPanel extends ArrangedLabelFieldPanel implements Pa
         logFile.setText(tg.getLogFilename());
         iterations.setText(tg.getIterationsLimit());
         concurrLimit.setText("1000");
+        if (showIdentifier) {
+            useIdentifier.setSelected(tg.getUseIdentifier());
+            propertiesIdentifier.setText(tg.getIdentifier());
+        }
         unitMinutes.setSelected(true);
         if (tg instanceof ArrivalsThreadGroup) {
             ArrivalsThreadGroup atg = (ArrivalsThreadGroup) tg;
@@ -57,6 +71,10 @@ public class AdditionalFieldsPanel extends ArrangedLabelFieldPanel implements Pa
     public void UItoModel(AbstractDynamicThreadGroup tg, JMeterVariableEvaluator evaluator) {
         tg.setLogFilename(evaluator.evaluate(logFile.getText()));
         tg.setIterationsLimit(evaluator.evaluate(iterations.getText()));
+        if (showIdentifier) {
+            tg.setUseIdentifier(useIdentifier.isSelected());
+            tg.setIdentifier(evaluator.evaluate(propertiesIdentifier.getText()));
+        }
         if (unitGroup.getSelection() != null) {
             tg.setUnit(unitGroup.getSelection().getActionCommand());
         }
@@ -71,6 +89,7 @@ public class AdditionalFieldsPanel extends ArrangedLabelFieldPanel implements Pa
         logFile.setText("");
         iterations.setText("");
         concurrLimit.setText("1000");
+        propertiesIdentifier.setText("");
         unitMinutes.setSelected(true);
     }
 

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/ArrivalsThreadGroupGui.java
@@ -32,7 +32,7 @@ public class ArrivalsThreadGroupGui extends AbstractDynamicThreadGroupGui {
 
     @Override
     protected AdditionalFieldsPanel getAdditionalFieldsPanel() {
-        return new AdditionalFieldsPanel(true);
+        return new AdditionalFieldsPanel(true, false);
     }
 
 

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroup.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroup.java
@@ -5,25 +5,94 @@ import org.apache.jmeter.engine.StandardJMeterEngine;
 import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.threads.ListenerNotifier;
+import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
 
 public class FreeFormArrivalsThreadGroup extends ArrivalsThreadGroup {
     public static final String SCHEDULE = "Schedule";
+    public static final String DEFAULT_IDENTIFIER_PROPERTY_NAME = "arrivals.schedule";
+    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final int START_THREADS_CNT_FIELD_NO = 0;
+    private static final int END_THREADS_CNT_FIELD_NO = 1;
+    private static final int DURATION_TIME_NO = 2;
+
+
+    private static void parseChunk(String chunk, PowerTableModel model) {
+
+        String[] parts = chunk.split("[(,]");
+        String loadVar = parts[0].trim();
+
+        if (loadVar.equalsIgnoreCase("spawn")) {
+            Integer[] row = new Integer[3];
+            row[START_THREADS_CNT_FIELD_NO] = Integer.parseInt(parts[1].trim());
+            row[END_THREADS_CNT_FIELD_NO] = Integer.parseInt(parts[2]);
+            row[DURATION_TIME_NO] = JMeterPluginsUtils.getSecondsForShortString(parts[3]);
+            model.addRow(row);
+        } else {
+            throw new RuntimeException("Unknown load type: " + parts[0]);
+        }
+    }
+
+    public CollectionProperty getData() {
+        JMeterProperty prop = getProperty(SCHEDULE);
+        String propertyName = getIdentifier().isEmpty() ? DEFAULT_IDENTIFIER_PROPERTY_NAME : getIdentifier();
+        if (!(prop instanceof CollectionProperty)) {
+            prop = new CollectionProperty();
+        }
+
+        JMeterProperty brokenProp = getProperty(propertyName);
+        JMeterProperty usualProp = getProperty(SCHEDULE);
+
+        if (brokenProp instanceof CollectionProperty) {
+            if (usualProp == null || usualProp instanceof NullProperty) {
+                log.warn("Copying '" + propertyName + "' into '" + SCHEDULE + "'");
+                JMeterProperty newProp = brokenProp.clone();
+                newProp.setName(SCHEDULE);
+                setProperty(newProp);
+            }
+            log.warn("Removing property '" + propertyName + "' as invalid");
+            removeProperty(propertyName);
+        }
+        if (getUseIdentifier()) {
+            CollectionProperty overrideProp = getLoadFromExternalProperty(getIdentifier());
+            if (overrideProp != null) {
+                return overrideProp;
+            }
+        }
+        return (CollectionProperty) prop;
+    }
 
     public void setData(PowerTableModel model) {
         CollectionProperty prop = JMeterPluginsUtils.tableModelRowsToCollectionProperty(model, SCHEDULE);
         setProperty(prop);
     }
 
-    public CollectionProperty getData() {
-        JMeterProperty prop = getProperty(SCHEDULE);
-        if (prop instanceof CollectionProperty) {
-            return (CollectionProperty) prop;
-        } else {
-            return new CollectionProperty();
+    private CollectionProperty getLoadFromExternalProperty(String propertyName) {
+        String externalDataProperty = propertyName.isEmpty() ? DEFAULT_IDENTIFIER_PROPERTY_NAME : propertyName;
+        String loadProp = JMeterUtils.getProperty(externalDataProperty);
+        log.debug("Profile prop: " + loadProp);
+        if (loadProp != null && loadProp.length() > 0) {
+//            expected format : arrivals.schedule="spawn(1,13,16s) spawn(13,13,10m)"
+            log.info("GUI threads profile will be ignored");
+            PowerTableModel dataModel = new PowerTableModel(FreeFormLoadPanel.getColumnIdentifiers(), FreeFormLoadPanel.getColumnClasses());
+            String[] chunks = loadProp.split("\\)");
+            for (String chunk : chunks) {
+                try {
+                    parseChunk(chunk, dataModel);
+                } catch (RuntimeException e) {
+                    log.warn("Wrong  chunk ignored: " + chunk, e);
+                }
+            }
+            log.debug("Setting threads profile from property " + externalDataProperty + ": " + loadProp);
+            return JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, FreeFormArrivalsThreadGroup.SCHEDULE);
         }
+        return null;
     }
+
 
     @Override
     protected Thread getThreadStarter(int groupIndex, ListenerNotifier listenerNotifier, ListedHashTree testTree, StandardJMeterEngine engine) {

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadGroupGui.java
@@ -52,7 +52,7 @@ public class FreeFormArrivalsThreadGroupGui extends AbstractDynamicThreadGroupGu
 
     @Override
     protected AdditionalFieldsPanel getAdditionalFieldsPanel() {
-        return new AdditionalFieldsPanel(true);
+        return new AdditionalFieldsPanel(true, true);
     }
 
     protected void setChartPropertiesFromTG(AbstractDynamicThreadGroup tg) {
@@ -100,6 +100,7 @@ public class FreeFormArrivalsThreadGroupGui extends AbstractDynamicThreadGroupGu
             double to = evaluator.getDouble(record.get(1));
             double during = evaluator.getDouble(record.get(2));
             row.add(offset * 1000, from);
+
             offset += during * tg.getUnitFactor();
             row.add(offset * 1000, to);
             totalArrivals += during * from + during * (to - from) / 2;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarter.java
@@ -6,8 +6,8 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.threads.ListenerNotifier;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FreeFormArrivalsThreadStarter extends ArrivalsThreadStarter {
     private static final Logger log = LoggerFactory.getLogger(FreeFormArrivalsThreadStarter.class);
@@ -25,7 +25,12 @@ public class FreeFormArrivalsThreadStarter extends ArrivalsThreadStarter {
         int offset = 0;
         while (it.hasNext()) {
             CollectionProperty record = (CollectionProperty) it.next();
-            double chunkLen = record.get(2).getDoubleValue() * arrivalsTG.getUnitFactor();
+            double chunkLen;
+            if (arrivalsTG.getUseIdentifier()) {
+                chunkLen = record.get(2).getDoubleValue();
+            } else {
+                chunkLen = record.get(2).getDoubleValue() * arrivalsTG.getUnitFactor();
+            }
             double timeProgress = this.rollingTime / 1000.0 - startTime;
             double chunkProgress = (timeProgress - offset) / chunkLen;
             offset += chunkLen;

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormLoadPanel.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/arrivals/FreeFormLoadPanel.java
@@ -14,6 +14,15 @@ public class FreeFormLoadPanel extends Grid implements ParamsPanel {
     private static final Class[] columnClasses = new Class[]{String.class, String.class, String.class};
     private static final String[] defaultValues = new String[]{"1", "10", "60"};
 
+
+    public static String[] getColumnIdentifiers() {
+        return columnIdentifiers;
+    }
+
+    public static Class[] getColumnClasses() {
+        return columnClasses;
+    }
+
     public FreeFormLoadPanel() {
         super("Threads Schedule", columnIdentifiers, columnClasses, defaultValues);
     }

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadGroupGui.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/concurrency/ConcurrencyThreadGroupGui.java
@@ -30,7 +30,7 @@ public class ConcurrencyThreadGroupGui extends AbstractDynamicThreadGroupGui {
 
     @Override
     protected AdditionalFieldsPanel getAdditionalFieldsPanel() {
-        return new AdditionalFieldsPanel(false);
+        return new AdditionalFieldsPanel(false, false);
     }
 
 

--- a/plugins/casutg/src/test/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarterTest.java
+++ b/plugins/casutg/src/test/java/com/blazemeter/jmeter/threads/arrivals/FreeFormArrivalsThreadStarterTest.java
@@ -5,13 +5,17 @@ import kg.apc.emulators.TestJMeterUtils;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.threads.ListenerNotifier;
+import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
+
 
 public class FreeFormArrivalsThreadStarterTest {
     private static final Logger log = LoggerFactory.getLogger(FreeFormArrivalsThreadStarterTest.class);
@@ -19,6 +23,38 @@ public class FreeFormArrivalsThreadStarterTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestJMeterUtils.createJmeterEnv();
+    }
+
+
+    @Test
+    public void testCustomProperties() {
+        CollectionProperty sched = new CollectionProperty();
+        sched.addProperty(getRow(1, 10, 30));
+        sched.addProperty(getRow(10, 10, 5));
+        sched.addProperty(getRow(10, 1, 15));
+//        sched.addProperty(new StringProperty("arrivals.schedule.1", "spawn(1,10,30s) spawn(10,10,5s) spawn(10,1,15s)"));
+        JMeterUtils.getJMeterProperties().put("arrivals.schedule.1", "spawn(1,10,30s) spawn(10,10,5s) spawn(10,1,15s)");
+        FreeFormArrivalsThreadGroup atg = new FreeFormArrivalsThreadGroup();
+        atg.setUseIdentifier(true);
+        atg.setIdentifier("arrivals.schedule.1");
+        atg.setProperty(sched);
+        FreeFormArrivalsThreadStarterEmul obj = new FreeFormArrivalsThreadStarterEmul(atg);
+        List<Double> resultList = new ArrayList<>();
+
+
+        for (int n = 0; n < 60; n++) {
+            resultList.add(obj.getCurrentRate());
+            log.error("Rate " + n + ": " + obj.getCurrentRate());
+            obj.addRollingTime(1000);
+        }
+
+//        List<Double> expectedList = Arrays.asList(1.4, 1.3, 1.2);
+//
+//        assertThat(resultList)
+//                .containsExactlyElementsOf(expectedList);
+////        assertThat(actual, contains(expectedList));
+////
+////        Assert.assertThat(resultList, (Matcher<? super List<Double>>) contains(expectedList));
     }
 
     @Test
@@ -32,7 +68,7 @@ public class FreeFormArrivalsThreadStarterTest {
         atg.setProperty(sched);
         FreeFormArrivalsThreadStarterEmul obj = new FreeFormArrivalsThreadStarterEmul(atg);
         for (int n = 0; n < 60; n++) {
-            log.info("Rate " + n + ": " + obj.getCurrentRate());
+            log.error("Rate " + n + ": " + obj.getCurrentRate());
             obj.addRollingTime(1000);
         }
     }


### PR DESCRIPTION
When use many different FreeFormArrivalsTG, many times, it is required to change load profile for exact one TG.
With this issue, we can control complex profile with just using different properties for each unique TG.  