### PR TITLE
HLS Sampler: jackson-jaxb-annotations may require jaxb-api in some cases

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -542,7 +542,6 @@
           "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-annotations-2.10.2.jar",
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-databind-2.10.2.jar",
           "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-module-jaxb-annotations-2.10.2.jar",
-	  "jaxb-api>=2.3.1":"https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
           "stax2-api>=4.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/stax2-api-4.2.jar",
           "woodstox-core>=5.3.0":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/woodstox-core-5.3.0.jar"
         },
@@ -615,6 +614,7 @@
           "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-annotations-2.10.2.jar",
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-databind-2.10.2.jar",
           "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/jackson-module-jaxb-annotations-2.10.2.jar",
+          "jaxb-api>=2.3.1":"https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
           "stax2-api>=4.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/stax2-api-4.2.jar",
           "woodstox-core>=5.3.0":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/woodstox-core-5.3.0.jar"
         },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -542,6 +542,7 @@
           "jackson-annotations>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-annotations-2.10.2.jar",
           "jackson-databind>=2.10.2" : "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-databind-2.10.2.jar",
           "jackson-module-jaxb-annotations>=2.10.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/jackson-module-jaxb-annotations-2.10.2.jar",
+	  "jaxb-api>=2.3.1":"https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
           "stax2-api>=4.2":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/stax2-api-4.2.jar",
           "woodstox-core>=5.3.0":"https://github.com/Blazemeter/HLSPlugin/releases/download/v3.0/woodstox-core-5.3.0.jar"
         },


### PR DESCRIPTION
When another JMeter plugin auto-registers Jackson modules, it fails with exception:

> Uncaught Exception java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlElement in thread Thread[StandardJMeterEngine,5,main]. See log file for details.