### PR TITLE
new plug-in baolu-csv-data-file-config

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1425,5 +1425,24 @@
         ]
       }
     }
+  },
+  {
+    "id": "baolu-csv-data-file-config",
+    "name": "baolu-csv-data-file-config",
+    "description": "<ul><li>This plug-in supports automatic or manual csv data allocation for each thread.It has a similar LoadRunner capability parameterization.</li><li>If your request involves database update operation, using this plug-in in the test script can avoid lock waiting and improve the reliability of test results.</li></ul>",
+    "screenshotUrl": "https://github.com/LeeBaul/baolu-csv-data-file-config/blob/master/src/main/resources/images/imge02.png",
+    "helpUrl": "https://github.com/LeeBaul/baolu-csv-data-file-config",
+    "vendor": "libaolu",
+    "markerClass": "com.baolu.jmeter.config.BaoluCSVDataSetBeanInfo",
+    "componentClasses": [
+      "com.baolu.jmeter.config.BaoluCSVDataSet",
+      "com.baolu.jmeter.services.BaoluCSVFileReader",
+      "com.baolu.jmeter.services.FileServer"
+    ],
+    "versions": {
+      "1.2.0": {
+        "downloadUrl": "https://github.com/LeeBaul/baolu-csv-data-file-config/releases/download/v1.2.0/baolu-csv-data-file-config-1.2.0.jar"
+      }
+    }
   }
 ]


### PR DESCRIPTION
This plug-in supports automatic or manual csv data allocation for each thread.
It has a similar LoadRunner capability parameterization.
If your request involves database update operation, using this plug-in in the test script can avoid lock waiting and improve the reliability of test results.