### PR TITLE
Could kg.apc:jmeter-plugins-autostop:0.1 drop off redundant dependencies? 

### DIFF
--- a/plugins/autostop/pom.xml
+++ b/plugins/autostop/pom.xml
@@ -41,12 +41,72 @@
             <groupId>kg.apc</groupId>
             <artifactId>jmeter-plugins-cmn-jmeter</artifactId>
             <version>0.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jms_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>excalibur-pool</groupId>
+                    <artifactId>excalibur-pool-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>geronimo-spec</groupId>
+                    <artifactId>geronimo-spec-javamail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>geronimo-spec</groupId>
+                    <artifactId>geronimo-spec-jms</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.jcip</groupId>
+                    <artifactId>jcip-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>rome</groupId>
+                    <artifactId>rome</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>kg.apc</groupId>
             <artifactId>jmeter-plugins-emulators</artifactId>
             <version>0.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jms_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>excalibur-pool</groupId>
+                    <artifactId>excalibur-pool-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Hi! I found the pom file of project **_kg.apc:jmeter-plugins-autostop:0.1_** introduced **_115_** dependencies. However, among them, **_11_** libraries (**_9%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
net.jcip:jcip-annotations:jar:1.0:compile
javax.mail:mail:jar:1.5.0-b01:compile
xml-apis:xml-apis:jar:1.4.01:compile
geronimo-spec:geronimo-spec-javamail:jar:1.3.1-rc3:compile
excalibur-pool:excalibur-pool-api:jar:2.1:compile
javax.activation:activation:jar:1.1:compile
geronimo-spec:geronimo-spec-jms:jar:1.1-rc4:compile
rome:rome:jar:1.0:compile
org.apache.geronimo.specs:geronimo-jms_1.1_spec:jar:1.1.1:compile
javax.servlet:servlet-api:jar:2.3:compile
xml-apis:xmlParserAPIs:jar:2.0.2:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.mail:mail:jar:1.5.0-b01:compile_** incorporates an incompatible license CDDL (CDDL cannot be used by the project with license The Apache Software License, Version 2.0), one of the redundant dependencies **_javax.activation:activation:jar:1.1:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 cannot be used by the project with license The Apache Software License, Version 2.0). As such, I suggest a refactoring operation for **_kg.apc:jmeter-plugins-autostop:0.1_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_jdom:jdom::1.0:compile(149KB)_** are invoked by the projects. When we remove the redundant dependency **_rome:rome::1.0:compile_**, the above **_jdom:jdom::1.0:compile(149KB)_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_kg.apc:jmeter-plugins-autostop:0.1_**’s maven tests.

Best regards