### PR TITLE
Add datadog-backend-listener v0.3.0

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1275,6 +1275,12 @@
       "org.datadog.jmeter.plugins.metrics.ConcurrentAggregator"
     ],
     "versions": {
+      "0.3.0": {
+        "downloadUrl": "https://github.com/DataDog/jmeter-datadog-backend-listener/releases/download/0.3.0/jmeter-datadog-backend-listener-0.3.0.jar",
+        "depends": [
+          "jmeter-core"
+        ]
+      },
       "0.2.0": {
         "downloadUrl": "https://github.com/DataDog/jmeter-datadog-backend-listener/releases/download/0.2.0/jmeter-datadog-backend-listener-0.2.0.jar",
         "depends": [


### PR DESCRIPTION
Updating the Datadog plugin to 0.3.0. 

Note: Do not merge until https://github.com/DataDog/jmeter-datadog-backend-listener/pull/29 is merged and 0.3.0 is actually released.