### PR TITLE
__strReplaceRegex instead of __strReplace

### DIFF
--- a/plugins/functions/src/main/java/kg/apc/jmeter/functions/StrReplaceRegex.java
+++ b/plugins/functions/src/main/java/kg/apc/jmeter/functions/StrReplaceRegex.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class StrReplaceRegex extends AbstractFunction {
 
     private static final List<String> desc = new LinkedList<String>();
-    private static final String KEY = "__strReplace";
+    private static final String KEY = "__strReplaceRegex";
 
     static {
         desc.add("String to get part of");


### PR DESCRIPTION
Key of the StrReplaceRegex function seems incorrect, it should be "__strReplaceRegex", not "__strReplace".