### PR TITLE
HTTP2 plugin release 2.0.2

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -866,6 +866,25 @@
           "jetty-io>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/jetty-io-11.0.6.jar",
           "jetty-util>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/jetty-util-11.0.6.jar"
         }
+      },
+	  "2.0.2": {
+        "changes": "Improvements in performance, memory usage and connections",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jmeter-bzm-http2-2.0.2.jar",
+        "depends": [
+          "jmeter-http"
+        ],
+        "libs": {
+          "http2-client>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-client-11.0.10.jar",
+          "http2-common>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-common-11.0.10.jar",
+          "http2-hpack>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-hpack-11.0.10.jar",
+          "http2-http-client-transport>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-http-client-transport-11.0.10.jar",
+          "jetty-alpn-client>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-alpn-client-11.0.10.jar",
+          "jetty-alpn-java-client>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-alpn-java-client-11.0.10.jar",
+          "jetty-client>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-client-11.0.10.jar",
+          "jetty-http>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-http-11.0.10.jar",
+          "jetty-io>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-io-11.0.10.jar",
+          "jetty-util>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-util-11.0.10.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
This release has fixes for the following issues

https://github.com/Blazemeter/jmeter-http2-plugin/issues/24 To improve scalability: Changed the default configuration of handling threads and connections. Memory management in request is also changed to improve its management and eliminate memory allocation errors. The initialization process in interactions was changed to minimize stress on the system.
https://github.com/Blazemeter/jmeter-http2-plugin/issues/25 jMeter Property is incorporated to be able to assign the maximum waiting time for an idle connection.
https://github.com/Blazemeter/jmeter-http2-plugin/issues/26 The accept encoding and user agent headers that were assigned by default by Jetty are removed
https://github.com/Blazemeter/jmeter-http2-plugin/issues/36 Maximum Request Timeout: The default behavior is changed, the timeout 

The following dependency update was also made

Bumps jetty-server from 11.0.6 to 11.0.10