### PR TITLE
Partial fix for Throughput Shaping Timer

### DIFF
--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -167,8 +167,14 @@ public class VariableThroughputTimer
         if (log.isDebugEnabled()) {
             log.debug("Calculating {} {} {}", millisSinceLastSecond, cntSent * msecPerReq, cntSent);
         }
+        
+        
         if (millisSinceLastSecond < (cntSent * msecPerReq)) {
-            // TODO : Explain this for other maintainers
+            //this code allows for very big number of threads to be fired each second (at most 1 divided by how much time "delay" runs because it's synchronized)
+            //each second has number of requests to fire
+            //this condition evaluates to true if threads have been firing (executing "sample" and then executing "delay") quickly enough since the second started
+            //otherwise next thread should be fired instantly
+            
             // cntDelayed + 1 : Current threads waiting + this thread
             return (int) (1 + 1000.0 * (cntDelayed + 1) / rps);
         }

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -169,7 +169,7 @@ public class VariableThroughputTimer
         }
         
         
-        if (millisSinceLastSecond < (cntSent * msecPerReq)) {
+        if (millisSinceLastSecond < (cntSent * msecPerReq) || msecPerReq > 1000) {
             //this code allows for very big number of threads to be fired each second (at most 1 divided by how much time "delay" runs because it's synchronized)
             //each second has number of requests to fire
             //this condition evaluates to true if threads have been firing (executing "sample" and then executing "delay") quickly enough since the second started


### PR DESCRIPTION
This PR partially fixes erratic behaviour of Throughput Shaping Timer with low requested intensity.

This is the problem: 
![TST_MCVE](https://user-images.githubusercontent.com/54845956/208082030-d35e685a-cda3-496f-90cf-1be253a0f8e2.png)
[TST_MCVE.zip](https://github.com/undera/jmeter-plugins/files/10245065/TST_MCVE.zip)

Actual intensity might strongly depend on what exactly the requested intensity is and how many threads there are.

The timer is still not guaranteed to work correctly in specific but realistic situaitons.