### PR TITLE
Added support for srandmember and lmove for queue-like polling [performance]

### DIFF
--- a/plugins/redis/pom.xml
+++ b/plugins/redis/pom.xml
@@ -12,7 +12,8 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-redis</artifactId>
-    <version>0.5</version>
+    <version>0.6</version>
+
 
     <name>Redis</name>
     <description>Redis</description>
@@ -34,6 +35,11 @@
             <id>team</id>
             <name>jmeter-plugins.org</name>
             <email>jmeter-plugins@googlegroups.com</email>
+        </developer>
+        <developer>
+            <id>private</id>
+            <name>Kuba Dering</name>
+            <email>kb.dering@gmail.com</email>
         </developer>
     </developers>
 
@@ -73,11 +79,43 @@
 
         <!-- https://mvnrepository.com/artifact/ai.grakn/redis-mock -->
         <dependency>
-            <groupId>ai.grakn</groupId>
-            <artifactId>redis-mock</artifactId>
-            <version>0.1.6</version>
+            <groupId>com.github.fppt</groupId>
+            <artifactId>jedis-mock</artifactId>
+            <version>1.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_core</artifactId>
+            <version>2.13</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-math3</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-pool2</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_core</artifactId>
+            <version>2.13</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-math3</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-pool2</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>
+
 </project>

--- a/site/dat/wiki/RedisDataSet.wiki
+++ b/site/dat/wiki/RedisDataSet.wiki
@@ -113,6 +113,8 @@ The JMX can be downloaded [/editor/?utm_source=jpgc&utm_medium=openurl&utm_campa
 == Technical Details ==
 
 The RedisDataSet uses the [https://github.com/xetorthio/jedis Jedis Java Redis library] for connection and access operations.
+Starting from version 0.6, RedisDataSet uses  [https://redis.io/commands/srandmember/ srandmember] and [https://redis.io/commands/lmove/ lmove] commands.
+For Redis versions below 6.2.0, you can define a "plugins.redis.legacy=true" property in jmeter.properties.
 
 For data loaded into a Redis set, RedisDataSet uses [/path/to/redis/url spop] and [https://redis.io/commands/sadd sadd] commands.
 


### PR DESCRIPTION
- Changed the default jedis commands to lmove + srandmember (4x performance improvement)
- Updated the redis mock library to support these commands
- Introduced new property for legacy support (redis version < 6.2.0)
- Cached polling strategy selection - replaced with Strategy pattern for extendability
- added dependencies for local development on m1 macs 