### PR TITLE
Update AutoStop.java

### DIFF
--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
@@ -268,6 +268,7 @@ public class AutoStop
 
     private void stopTest() {
         stopTries++;
+        System.setProperty("auto_stopped", "true");
 
         if (JMeter.isNonGUI()) {
             log.info("Stopping JMeter via UDP call");

--- a/site/dat/wiki/AutoStop.wiki
+++ b/site/dat/wiki/AutoStop.wiki
@@ -9,6 +9,7 @@ This criteria are used in OR logic, the component will ask JMeter to stop test
 if one of the criteria has been met.
 After 5 tries of "shutdown test" component will switch to more insistent "stop test",
 after 5 more it will try to "stop NOW".
+
 On initiating "shutdown test" AutoStop will create environment variable "auto_stopped" = "true" 
 which can be checked later in order to take additional actions on test failure (e.g. send alert). 
 

--- a/site/dat/wiki/AutoStop.wiki
+++ b/site/dat/wiki/AutoStop.wiki
@@ -9,6 +9,8 @@ This criteria are used in OR logic, the component will ask JMeter to stop test
 if one of the criteria has been met.
 After 5 tries of "shutdown test" component will switch to more insistent "stop test",
 after 5 more it will try to "stop NOW".
+On initiating "shutdown test" AutoStop will create environment variable "auto_stopped" = "true" 
+which can be checked later in order to take additional actions on test failure (e.g. send alert). 
 
 [/img/wiki/AutoStop1.png]
 


### PR DESCRIPTION
Add environment variable which indicates that threshold limit was hit and test was stopped. This is required later to check in Tear down thread group and act accordingly (e.g. in my case I want to send Slack message about failed test).