### PR TITLE
add new tool vdn-junit-reporter-kpi-from-jmeter-dashboard-stats

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1890,5 +1890,21 @@
           ]
         }
       }
+    },
+    {
+      "id": "vdn-junit-reporter-kpi-from-jmeter-dashboard-stats",
+      "name": "vdn@github - junit-reporter-kpi-from-jmeter-dashboard-stats tool",
+      "description": "A tool that creates a JUnit XML file with KPI rules from JMeter JMeter Dashboard stats.json and generates a result file in JUnit XML format and other formats : html, csv and json.",
+      "helpUrl": "https://github.com/vdaburon/JUnitReportKpiJMeterDashboardStats",
+      "screenshotUrl": "https://github.com/vdaburon/JUnitReportKpiJMeterDashboardStats/raw/main/doc/images/kpi_excel.png",
+      "vendor": "Vincent Daburon",
+      "markerClass": "io.github.vdaburon.jmeter.utils.jsonkpi.ToolInstaller",
+      "installerClass": "io.github.vdaburon.jmeter.utils.jsonkpi.ToolInstaller",
+      "versions": {
+        "1.4": {
+          "changes": "Version for jmeter-plugins-manager repo",
+          "downloadUrl": "https://github.com/vdaburon/JUnitReportKpiJMeterDashboardStats/releases/download/v1.4/junit-reporter-kpi-from-jmeter-dashboard-stats-1.4-jar-with-dependencies.jar"
+        }
+      }
     }
 ]


### PR DESCRIPTION
Add tool.
This tool creates a JUnit XML file with KPI rules from JMeter JMeter Dashboard stats.json and generates a result file in JUnit XML format and other formats  : html, csv and json.