### PR TITLE
Feature/tst magic property fix [functional]

### DIFF
--- a/plugins/tst/pom.xml
+++ b/plugins/tst/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-tst</artifactId>
-    <version>2.5</version>
+    <version>2.6</version>
 
     <name>Throughput shaping timer</name>
     <description>Throughput shaping timer</description>

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -191,7 +191,7 @@ public class VariableThroughputTimer
         } else {
             dataProperty = DATA_PROPERTY_POSTFIX;
         }
-        log.info("Load property set to {}", dataProperty);
+        log.debug("Load property set to {}", dataProperty);
     }
 
     public void setData(CollectionProperty rows) {
@@ -202,7 +202,7 @@ public class VariableThroughputTimer
         if (overrideProp != null) {
             return overrideProp;
         }
-        log.info("Loading profile from property {}", dataProperty);
+        log.debug("Loading profile from property {}", dataProperty);
         setDataProperty();
         return getProperty(dataProperty);
     }
@@ -256,7 +256,7 @@ public class VariableThroughputTimer
         String loadProp = JMeterUtils.getProperty(dataProperty);
         log.debug("Loading property: {}={}", dataProperty, loadProp);
         if (!StringUtils.isEmpty(loadProp)) {
-            log.info("GUI load profile will be ignored as property {} is defined", dataProperty);
+            log.debug("GUI load profile will be ignored as property {} is defined", dataProperty);
             PowerTableModel dataModel = new PowerTableModel(VariableThroughputTimer.columnIdentifiers, VariableThroughputTimer.columnClasses);
 
             String[] chunks = loadProp.split("\\)");
@@ -269,8 +269,8 @@ public class VariableThroughputTimer
                 }
             }
 
-            log.info("Setting load profile from property {}: {}", dataProperty, loadProp);
-            log.info("load profile resolved to", dataModel);
+            log.debug("Setting load profile from property {}: {}", dataProperty, loadProp);
+            log.debug("load profile resolved to", dataModel);
             overrideProp = JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, dataProperty);
         }
     }

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -21,7 +21,6 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.locks.Lock;
 
 public class VariableThroughputTimer
         extends AbstractTestElement
@@ -84,33 +83,33 @@ public class VariableThroughputTimer
      *
      * @return 0
      */
-    public synchronized long  delay() {
-            while (true) {
-                long curTimeMs = System.currentTimeMillis();
-                long millisSinceLastSecond = curTimeMs % 1000;
-                long nowInMsRoundedAtSec = curTimeMs - millisSinceLastSecond;
-                checkNextSecond(nowInMsRoundedAtSec);
-                int delayMs = getDelay(millisSinceLastSecond);
+    public synchronized long delay() {
+        while (true) {
+            long curTimeMs = System.currentTimeMillis();
+            long millisSinceLastSecond = curTimeMs % 1000;
+            long nowInMsRoundedAtSec = curTimeMs - millisSinceLastSecond;
+            checkNextSecond(nowInMsRoundedAtSec);
+            int delayMs = getDelay(millisSinceLastSecond);
 
-                if (stopping) {
-                    delayMs = delayMs > 0 ? 10 : 0;
-                    notify(); // NOSONAR Don't notifyAll as cost is too big in terms of performances
-                }
-
-                if (delayMs < 1) {
-                    notify(); // NOSONAR Don't notifyAll as cost is too big in terms of performances
-                    break;
-                }
-                cntDelayed++;
-                try {
-                    wait(delayMs);
-                } catch (InterruptedException ex) {
-                    log.debug("Waiting thread was interrupted", ex);
-                    Thread.currentThread().interrupt();
-                }
-                cntDelayed--;
+            if (stopping) {
+                delayMs = delayMs > 0 ? 10 : 0;
+                notify(); // NOSONAR Don't notifyAll as cost is too big in terms of performances
             }
-            cntSent++;
+
+            if (delayMs < 1) {
+                notify(); // NOSONAR Don't notifyAll as cost is too big in terms of performances
+                break;
+            }
+            cntDelayed++;
+            try {
+                wait(delayMs);
+            } catch (InterruptedException ex) {
+                log.debug("Waiting thread was interrupted", ex);
+                Thread.currentThread().interrupt();
+            }
+            cntDelayed--;
+        }
+        cntSent++;
 
         return 0;
     }

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
@@ -120,7 +120,7 @@ public class VariableThroughputTimerGui
 
     @Override
     public void modifyTestElement(TestElement tg) {
-        log.info("Modify test element");
+        log.debug("Modify test element");
         super.configureTestElement(tg);
         if (grid.isEditing()) {
             grid.getCellEditor().stopCellEditing();
@@ -128,7 +128,7 @@ public class VariableThroughputTimerGui
 
         if (tg instanceof VariableThroughputTimer) {
             VariableThroughputTimer utg = (VariableThroughputTimer) tg;
-            log.info("property " + utg.getDataProperty());
+            log.debug("property " + utg.getDataProperty());
             CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(tableModel, utg.getDataProperty());
             utg.setData(rows);
         }

--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimerGui.java
@@ -120,16 +120,16 @@ public class VariableThroughputTimerGui
 
     @Override
     public void modifyTestElement(TestElement tg) {
-        //log.info("Modify test element");
+        log.info("Modify test element");
         super.configureTestElement(tg);
-
         if (grid.isEditing()) {
             grid.getCellEditor().stopCellEditing();
         }
 
         if (tg instanceof VariableThroughputTimer) {
             VariableThroughputTimer utg = (VariableThroughputTimer) tg;
-            CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(tableModel, VariableThroughputTimer.DATA_PROPERTY);
+            log.info("property " + utg.getDataProperty());
+            CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(tableModel, utg.getDataProperty());
             utg.setData(rows);
         }
     }
@@ -160,7 +160,8 @@ public class VariableThroughputTimerGui
 
         if (tableModel != null) {
             VariableThroughputTimer utgForPreview = new VariableThroughputTimer();
-            utgForPreview.setData(JMeterPluginsUtils.tableModelRowsToCollectionPropertyEval(tableModel, VariableThroughputTimer.DATA_PROPERTY));
+            utgForPreview.setName(getName());
+            utgForPreview.setData(JMeterPluginsUtils.tableModelRowsToCollectionPropertyEval(tableModel, utgForPreview.getDataProperty()));
             updateChart(utgForPreview);
         }
     }

--- a/plugins/tst/src/test/java/kg/apc/jmeter/timers/VariableThroughputTimerGuiTest.java
+++ b/plugins/tst/src/test/java/kg/apc/jmeter/timers/VariableThroughputTimerGuiTest.java
@@ -115,7 +115,7 @@ public class VariableThroughputTimerGuiTest {
     public void testConfigure() {
         System.out.println("configure");
         VariableThroughputTimer tg = new VariableThroughputTimer();
-        CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, VariableThroughputTimer.DATA_PROPERTY);
+        CollectionProperty rows = JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, tg.getDataProperty());
         tg.setData(rows);
         VariableThroughputTimerGui instance = new VariableThroughputTimerGui();
         //tg.setProperty(new ObjectProperty(AbstractThreadGroup.MAIN_CONTROLLER, tg));

--- a/plugins/tst/src/test/java/kg/apc/jmeter/timers/VariableThroughputTimerTest.java
+++ b/plugins/tst/src/test/java/kg/apc/jmeter/timers/VariableThroughputTimerTest.java
@@ -76,13 +76,43 @@ public class VariableThroughputTimerTest {
     
     @Test
     public void testDelay_Prop() {
+        String instanceName = "TestInstance";
         System.out.println("delay from property");
         String load = "const(10,10s) line(10,100,1m) step(5,25,5,1h)";
-        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY, load);
+        JMeterUtils.setProperty(instanceName + "." + VariableThroughputTimer.DATA_PROPERTY_POSTFIX, load);
         VariableThroughputTimer instance = new VariableThroughputTimer();
-        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY, ""); // clear!
+        instance.setName(instanceName);
+        JMeterUtils.setProperty(instance.getDataProperty(), ""); // clear!
         JMeterProperty result = instance.getData();
         assertEquals("[[10, 10, 10], [10, 100, 60], [5, 5, 3600], [10, 10, 3600], [15, 15, 3600], [20, 20, 3600], [25, 25, 3600]]", result.toString());
+    }
+
+
+    @Test
+    public void testDelay_DefaultPropOnUnnamedInstance(){
+        System.out.println("delay from default property");
+        String load = "const(20, 10s) line(20, 50, 1m)";
+        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY_POSTFIX, load);
+        // unnamed instance
+        VariableThroughputTimer instance = new VariableThroughputTimer();
+        instance.testStarted();
+        JMeterProperty result = instance.getData();
+        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY_POSTFIX, "");
+        assertEquals("[[20, 20, 10], [20, 50, 60]]", result.toString());
+
+    }
+
+    @Test
+    public void testDelay_DefaultPropOnNamedInstance(){
+        String name = "NamedInstance";
+        String load = "const(30, 10s) line(20, 100, 1m)";
+        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY_POSTFIX, load);
+        VariableThroughputTimer instance = new VariableThroughputTimer();
+        instance.setName(name);
+        instance.testStarted();
+        JMeterProperty result = instance.getData();
+        JMeterUtils.setProperty(VariableThroughputTimer.DATA_PROPERTY_POSTFIX, "");
+        assertEquals("[[30, 30, 10], [20, 100, 60]]", result.toString());
     }
 
     @Test
@@ -90,7 +120,7 @@ public class VariableThroughputTimerTest {
         System.out.println("delay 1000");
         VariableThroughputTimer instance = new VariableThroughputTimerEmul();
         instance.setName("TEST");
-        CollectionProperty prop = JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, VariableThroughputTimer.DATA_PROPERTY);
+        CollectionProperty prop = JMeterPluginsUtils.tableModelRowsToCollectionProperty(dataModel, instance.getDataProperty());
         instance.setData(prop);
         long start = System.currentTimeMillis();
         long result = 0;
@@ -126,7 +156,7 @@ public class VariableThroughputTimerTest {
     public void testGetData() {
         System.out.println("getData");
         VariableThroughputTimer instance = new VariableThroughputTimer();
-        instance.setData(new CollectionProperty(VariableThroughputTimer.DATA_PROPERTY, new LinkedList()));
+        instance.setData(new CollectionProperty(instance.getDataProperty(), new LinkedList()));
         JMeterProperty result = instance.getData();
         //System.err.println(result.getClass().getCanonicalName());
         assertTrue(result instanceof CollectionProperty);

--- a/site/dat/wiki/ThroughputShapingTimer.wiki
+++ b/site/dat/wiki/ThroughputShapingTimer.wiki
@@ -55,10 +55,13 @@ Properties are:
 
 == Special Property Processing ==
 
-There is a way to specify load pattern from special jmeter property {{{load_profile}}}.
+There is a way to specify load pattern from special jmeter property {{{tst-name.load_profile}}}, where tst-name
+is the name of the Throughput Shaping Timer to define the load pattern on.
+The {{{load.profile}}} jmeter property is used as a default if the {{{tst-name}}} is not defined.
+If neither the {{{tst_name.load_profile}}}  or default {{{load_profile}}} are defined, the values from GUI are taken
 Property can be specified either in user.properties file (jmeter.properties also applicable), or
-from command line like {{{-J "load\_profile=..."}}}. Make note that this property is temporary,
-and will be replaced by some GUI setting in future versions.
+from command line like {{{-J "load\_profile=..."}}}.
+
 
 Load pattern specified with set of function-like declarations.
 "Functions" may be of 3 types: const, line and step.
@@ -74,7 +77,31 @@ Duration value in every function may be specified with shorthand case-insensitiv
 
 Duration setting may be combined like _1d11h23m6s_.
 
-Example of load profile string: {{{load_profile=const(10,10s) line(10,100,1m) step(5,25,5,1h)}}}
+Example of load profile string: {{{my_timer.load_profile=const(10,10s) line(10,100,1m) step(5,25,5,1h)}}}
+Example of default load profile string : {{{load_profile=step(5, 50, 5, 2m) const(50, 10m)}}}
+
+Scenario 1:
+- Throughput Shaping Timer is named "my_timer"
+- The property {{{my_timer.load_profile}}} is not defined
+- {{{load_profile}}} is not defined
+Outcome:
+    Throughput will be shaped from values defined in GUI
+
+Scenario 2:
+- Throughput Shaping Timer is named "my_timer"
+- property {{{my_timer.load_profile}}} is defined {{{my_timer.load_profile=const(10, 1m)}}}
+Outcome:
+ Named property takes the first priority and the throughput will be shaped as defined in named property
+ The timer will attempt to keep the pace of 10 RPS for the duration of 1 minute
+
+ Scenario 3
+ - Throuhgput Shaping Timer is named "my_timer"
+ - property {{{my_timer.load_profile}}} is not defined
+ - property {{{load_profile}}} is defined {{{load_profile=step(5, 25, 5, 1m)}}}
+ Outcome:
+  Default property takes 2nd priority and the timer will attempt to generate the RPS defined in the {{{load_profile}} property}}}
+
+
 
 == Schedule Feedback Function ==
 There is special JMeter function that enables feeback loop for number of threads.


### PR DESCRIPTION
- Added support for multiple load_profile properties for Throughput Shaping Timer ({name}.load_property
- Property is parsed in GUI on each name update and visible in preview (if named property exists)
- backwards compatible with load_profile property and GUI (if the named property is not defined) 

Name was used as identifier to keep the compatibility with tstFeedback function