### PR TITLE
Add datadog-backend-listener v0.4.0

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1393,6 +1393,12 @@
       "org.datadog.jmeter.plugins.metrics.ConcurrentAggregator"
     ],
     "versions": {
+      "0.4.0": {
+        "downloadUrl": "https://github.com/DataDog/jmeter-datadog-backend-listener/releases/download/0.4.0/jmeter-datadog-backend-listener-0.4.0.jar",
+        "depends": [
+          "jmeter-core"
+        ]
+      },
       "0.3.1": {
         "downloadUrl": "https://github.com/DataDog/jmeter-datadog-backend-listener/releases/download/0.3.1/jmeter-datadog-backend-listener-0.3.1.jar",
         "depends": [


### PR DESCRIPTION
New version of the Datadog plugin (0.4.0) released.