### PR TITLE
HTTP2 plugin release 2.0.3

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -665,7 +665,7 @@
     "name": "BlazeMeter - HTTP/2 Plugin",
     "description": "HTTP/2 protocol sampler",
     "helpUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/blob/master/README.md",
-    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/jmeter-http2-plugin/master/syncRequest.png",
+    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/jmeter-http2-plugin/master/docs/addHTTP2Sampler.png",
     "vendor": "BlazeMeter",
     "installerClass": "com.blazemeter.jmeter.http2.Installer",
     "markerClass": "com.blazemeter.jmeter.http2.sampler.HTTP2Sampler",
@@ -884,6 +884,25 @@
           "jetty-http>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-http-11.0.10.jar",
           "jetty-io>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-io-11.0.10.jar",
           "jetty-util>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-util-11.0.10.jar"
+        }
+      },
+	  "2.0.3": {
+        "changes": "Added support for HTTP 1.x, ALPN, multiplexing, and parallel execution. Also improvements in performance, memory and connection usage",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jmeter-bzm-http2-2.0.3.jar",
+        "depends": [
+          "jmeter-http"
+        ],
+        "libs": {
+          "http2-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-client-11.0.15.jar",
+          "http2-common>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-common-11.0.15.jar",
+          "http2-hpack>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-hpack-11.0.15.jar",
+          "http2-http-client-transport>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-http-client-transport-11.0.15.jar",
+          "jetty-alpn-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-alpn-client-11.0.15.jar",
+          "jetty-alpn-java-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-alpn-java-client-11.0.15.jar",
+          "jetty-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-client-11.0.15.jar",
+          "jetty-http>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-http-11.0.15.jar",
+          "jetty-io>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-io-11.0.15.jar",
+          "jetty-util>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-util-11.0.15.jar"
         }
       }
     }


### PR DESCRIPTION
Added support for HTTP 1.x, ALPN, multiplexing, and parallel execution.
Also improvements in performance, memory and connection usage.
