### PR TITLE
[fix] - JedisException when test ends 

### DIFF
--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
@@ -227,11 +227,9 @@ public class RedisDataSet extends ConfigTestElement
             } catch (JedisDataException jde) {
                 log.error("Failed to retrieve data from redis key {}", redisKey);
             }
-
             if (null == line) {
                 throw new JMeterStopThreadException("End of redis data detected");
             }
-
             final String names = variableNames;
             if (vars == null) {
                 vars = JOrphanUtils.split(names, ",");
@@ -247,7 +245,6 @@ public class RedisDataSet extends ConfigTestElement
         } finally {
             pool.returnResource(connection);
         }
-
     }
 
     @Override

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
@@ -257,7 +257,10 @@ public class RedisDataSet extends ConfigTestElement
 
     @Override
     public void testEnded(String host) {
-        pool.getResource();
+        int idleConn = pool.getNumIdle();
+        for(int i=0;i<idleConn;i++){
+           pool.getResource();
+        }
         pool.destroy();
     }
 

--- a/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
+++ b/plugins/redis/src/main/java/kg/apc/jmeter/config/redis/RedisDataSet.java
@@ -226,11 +226,12 @@ public class RedisDataSet extends ConfigTestElement
                 line = pollingStrategy.getDataFromConnection(connection, redisKey);
             } catch (JedisDataException jde) {
                 log.error("Failed to retrieve data from redis key {}", redisKey);
-
             }
+
             if (null == line) {
                 throw new JMeterStopThreadException("End of redis data detected");
             }
+
             final String names = variableNames;
             if (vars == null) {
                 vars = JOrphanUtils.split(names, ",");
@@ -246,6 +247,7 @@ public class RedisDataSet extends ConfigTestElement
         } finally {
             pool.returnResource(connection);
         }
+
     }
 
     @Override
@@ -255,6 +257,7 @@ public class RedisDataSet extends ConfigTestElement
 
     @Override
     public void testEnded(String host) {
+        pool.getResource();
         pool.destroy();
     }
 


### PR DESCRIPTION
Fixing the Exception:  redis.clients.jedis.exceptions.JedisException: Could not return the broken resource to the pool
Which is triggered when jmeter calls testEnded() method. 
Evidence below:
![image](https://github.com/undera/jmeter-plugins/assets/42453088/1322828d-e185-446f-88fb-e9d0d5ce345a)

I added a log to show the total number of idle connections before calling ``pool.destroy()`` at ``testEnded(String host)`` and noticed that the number of idle connections was equal to the number of exceptions. As we can see here:
![image](https://github.com/undera/jmeter-plugins/assets/42453088/82350365-7aa6-40d1-a793-406fc2b20099)

Then I forced JMeter to consume all the connections before calling ``pool.destroy()``.
I know the problem is in Jedis itself, as it was already addressed in https://github.com/redis/jedis/pull/3353. The other possible solution would be updating the Jedis version, but I don't know if that would lead to any compatibility issue.