### PR TITLE
add initial version of HAR Importer

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -2008,5 +2008,23 @@
 	        "depends":["jmeter-core"]
 		}
 	}
+  },
+  {
+    "id": "jmeter-har-import",
+    "name": "HAR (HTTP Archive) Import",
+    "description": "This plugin allows you to import HAR files into JMeter and convert them into HTTP Request Samplers for easier recording.",
+    "vendor": "Qytera GmbH",
+    "screenshotUrl": "https://raw.githubusercontent.com/Qytera-Gmbh/JMeterHARImporterPlugin/main/screenshot-usage.png",
+    "helpUrl": "https://github.com/Qytera-Gmbh/JMeterHARImporterPlugin/blob/main/README.md",
+    "markerClass": "de.qytera.jmeterharimporter.HARImporter",
+    "componentClasses": [
+      "de.qytera.jmeterharimporter.HARImporter",
+      "de.qytera.jmeterharimporter.HARImportMenu"
+    ],
+    "versions": {
+      "0.1.0": {
+        "downloadUrl": "https://github.com/Qytera-Gmbh/JMeterHARImporterPlugin/releases/download/v0.1.0/jmeter-har-import-plugin-v0.1.0.jar"
+      }
+    }
   }
 ]


### PR DESCRIPTION
Add a new importer that is able to take the browsers HAR files (HTTP Archive) and convert them into HTTP Samplers, Constant Timers, add cookies and headers and sort them into modules.

The motivation is to allow customers to record http requests without any knowledge of JMeter and without the hurdle of proxies.

@see https://github.com/Qytera-Gmbh/JMeterHARImporterPlugin/blob/main/README.md