### PR TITLE
vdn-har-convertor-jmeter-tool v3.2

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1960,9 +1960,9 @@
           "changes": "Add Button 'CONVERT AND LOAD GENERATED SCRIPT'. File Chooser select only file and no directory.",
           "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v3.0/har-convertor-jmeter-plugin-3.0-jar-with-dependencies.jar"
         },
-	"3.1": {
-          "changes": "Remove the header Content-length because the length is computed by JMeter when the request is created. POST or PUT could have query string and body with content so add query string to the path. Set Content Encoding to UFT-8 for POST or PUT method and request Content-Type:application/json. Add body data content in record.xml for PUT and PATCH methods.",
-          "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v3.1/har-convertor-jmeter-plugin-3.1-jar-with-dependencies.jar"
+	"3.2": {
+          "changes": "Remove the header Content-length because the length is computed by JMeter when the request is created. POST or PUT could have query string and body with content so add query string to the path. Set Content Encoding to UFT-8 for POST or PUT method and request Content-Type:application/json. Add body data content in record.xml for PUT and PATCH methods. encode value for x-www-form-urlencoded when value contains space, equal, slash or plus characters.",
+          "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v3.2/har-convertor-jmeter-plugin-3.2-jar-with-dependencies.jar"
         }
       }
    },

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1959,6 +1959,10 @@
 	"3.0": {
           "changes": "Add Button 'CONVERT AND LOAD GENERATED SCRIPT'. File Chooser select only file and no directory.",
           "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v3.0/har-convertor-jmeter-plugin-3.0-jar-with-dependencies.jar"
+        },
+	"3.1": {
+          "changes": "Remove the header Content-length because the length is computed by JMeter when the request is created. POST or PUT could have query string and body with content so add query string to the path. Set Content Encoding to UFT-8 for POST or PUT method and request Content-Type:application/json. Add body data content in record.xml for PUT and PATCH methods.",
+          "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v3.1/har-convertor-jmeter-plugin-3.1-jar-with-dependencies.jar"
         }
       }
    },


### PR DESCRIPTION
vdn-har-convertor-jmeter-tool v3.1, use library har-to-jmeter-convertor-2.2 that correct bugs.
* Remove the header 'Content-length' because the length is computed by JMeter when the request is created. 
* POST or PUT could have query string and body with content so add query string to the path. 
* Set Content Encoding to UFT-8 for POST or PUT method and request Content-Type : application/json. 
* Add body data content in Record.xml for PUT and PATCH methods.