### PR TITLE
Fix news/changes on release v2.5

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -10,42 +10,30 @@
     "versions": {
       "0.1": {
         "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-debugger-0.1.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       },
       "0.2": {
         "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-debugger-0.2.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       },
       "0.3": {
         "downloadUrl": "https://jmeter-plugins.org/files/thirdparty/jmeter-debugger-0.3.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       },
       "0.4": {
         "changes": "Fixed bugs on not evaluating variables",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-debugger/releases/download/0.4/jmeter-debugger-0.4.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       },
       "0.5": {
         "changes": "<p>- Add last sampler result tab;</p><p>- Choose TG from context of tree;</p><p>- Fixed italic font in tree not shown on Mac;</p><p>- Fixed blue color for current element is blue-on-blue for Mac;</p><p>- Fixed logging lab for old jmeter versions;</p><p>- Fixed clear data in info tabs and listeners;</p><p>- Fixed modification thread groups;</p>",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-debugger/releases/download/0.5/jmeter-debugger-0.5.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       },
       "0.6": {
         "changes": "Fix variables in assertions",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-debugger/releases/download/0.6/jmeter-debugger-0.6.jar",
-        "depends": [
-          "jmeter-core"
-        ]
+        "depends": ["jmeter-core"]
       }
     }
   },
@@ -173,9 +161,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.2": {
         "changes": "Fixed class name clash with Debugger plugin",
@@ -183,9 +169,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.3": {
         "changes": "Fixed remote execution",
@@ -193,9 +177,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.4": {
         "changes": "Fixed reset Thread Context in all AbstractTestElements",
@@ -203,9 +185,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.5": {
         "changes": "Fixed Concurrency Modification exception for Config elements",
@@ -213,9 +193,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.7": {
         "changes": "Fixed unnecessary TE clone",
@@ -223,9 +201,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.8": {
         "changes": "Fixed sample labels for JMeter 5.0",
@@ -233,9 +209,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.9": {
         "changes": "Fixed Test Actions (Start Next Thread Loop, Stop Thread, Stop All Threads)",
@@ -243,9 +217,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.10": {
         "changes": "Add ability to limit the number of thread to start to simulate browser's real threading",
@@ -253,9 +225,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "0.11": {
         "changes": "Fix parallel controller for JMeter 5.3+",
@@ -503,29 +473,21 @@
     "versions": {
       "1.0": {
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.0/jmeter-hls-1.0.jar",
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "1.1": {
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.1/jmeter-hls-1.1.jar",
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "1.2": {
         "changes": "Some bugs fixed",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/jmeter-hls-1.2/jmeter-hls-1.2.jar",
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "1.3": {
         "changes": "Plugin name has been changed to continue with the convention of BlazeMeter plugins.\nLogo has been added.\nIssue in live stream when it did not show results in View Results Tree has been fixed.",
         "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v1.3/jmeter-hls-1.3.jar",
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "2.0": {
         "changes": "Major new release with a lot of bug fixes and new features (simplified UI, granular assertions, etc). Please check the readme",
@@ -533,9 +495,7 @@
         "libs": {
           "hlsparserj>=1.0.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v2.0/hlsparserj-1.0.0.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       },
       "3.0": {
         "changes": "Major new release with support for MPEG DASH and new features (like automatic protocol recognition, sampler renaming, etc). Please check the readme",
@@ -616,9 +576,7 @@
           "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/stax2-api-4.2.jar",
           "woodstox-core>=5.3.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.1/woodstox-core-5.3.0.jar"
         },
-        "depends": [
-          "jmeter-http"
-        ]
+        "depends": ["jmeter-http"]
       }
     }
   },
@@ -642,9 +600,7 @@
       "1.6.2": {
         "changes": "Archive Java 8 HTTP2 Plugin",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.2/jmeter-bzm-http2-1.6.2.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.35.v20201120": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.2/http2-client-9.4.35.v20201120.jar",
           "http2-common>=9.4.35.v20201120": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.2/http2-common-9.4.35.v20201120.jar",
@@ -673,9 +629,7 @@
     "versions": {
       "1.0": {
         "downloadUrl": "https://github.com/Blazemeter/jmeter-bzm-plugins/releases/download/http2-1.0/jmeter-bzm-http2-1.0.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.5/jmeter-plugins-cmn-jmeter-0.5.jar",
           "jetty-client": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-client/9.4.0.v20161208/jetty-client-9.4.0.v20161208.jar",
@@ -692,9 +646,7 @@
       "1.1": {
         "changes": "Fix memory leak and JTL output error",
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.1/jmeter-bzm-http2-1.1.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.5/jmeter-plugins-cmn-jmeter-0.5.jar",
           "jetty-client": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-client/9.4.0.v20161208/jetty-client-9.4.0.v20161208.jar",
@@ -711,9 +663,7 @@
       "1.2": {
         "changes": "Fix HTTP2 plugin POST support to include proper request and fix issue with callback handler",
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.2/jmeter-bzm-http2-1.2.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
           "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
@@ -728,9 +678,7 @@
       "1.3": {
         "changes": "Added support for standards JMeter listeners and partial support for push promise",
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.3/jmeter-bzm-http2-1.3.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
           "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
@@ -745,9 +693,7 @@
       "1.4": {
         "changes": "Fixed serialization issue for JMeter distributed mode",
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=com/blazemeter/jmeter-bzm-http2/1.4/jmeter-bzm-http2-1.4.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-client/9.4.9.v20180320/http2-client-9.4.9.v20180320.jar",
           "http2-common>=9.4.9.v20180320": "http://search.maven.org/remotecontent?filepath=org/eclipse/jetty/http2/http2-common/9.4.9.v20180320/http2-common-9.4.9.v20180320.jar",
@@ -762,9 +708,7 @@
       "1.4.1": {
         "changes": "Fix issue handling http responses without body (like 204 status code)",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/jmeter-bzm-http2-1.4.1.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-client-9.4.9.v20180320.jar",
           "http2-common>=9.4.9.v20180320": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.4.1/http2-common-9.4.9.v20180320.jar",
@@ -779,9 +723,7 @@
       "1.5": {
         "changes": "Request methods PATCH & DELETE were added. Also support for no SSL connections and libraries updated.",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.5/jmeter-bzm-http2-1.5.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.26.v20200117": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.5/http2-client-9.4.26.v20200117.jar",
           "http2-common>=9.4.26.v20200117": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.5/http2-common-9.4.26.v20200117.jar",
@@ -796,9 +738,7 @@
       "1.6": {
         "changes": "Added support for Gzip in response headers and added data frame to PUT method",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6/jmeter-bzm-http2-1.6.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.26.v20200117": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6/http2-client-9.4.26.v20200117.jar",
           "http2-common>=9.4.26.v20200117": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6/http2-common-9.4.26.v20200117.jar",
@@ -813,9 +753,7 @@
       "1.6.1": {
         "changes": "Updated Jetty dependencies",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.1/jmeter-bzm-http2-1.6.1.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=9.4.35.v20201120": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.1/http2-client-9.4.35.v20201120.jar",
           "http2-common>=9.4.35.v20201120": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v1.6.1/http2-common-9.4.35.v20201120.jar",
@@ -830,9 +768,7 @@
       "2.0": {
         "changes": "Major release using as baseline Java 11 and Jetty 11, proxy support and many other new functionalities!",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0/jmeter-bzm-http2-2.0.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0/http2-client-11.0.6.jar",
           "http2-common>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0/http2-common-11.0.6.jar",
@@ -849,9 +785,7 @@
       "2.0.1": {
         "changes": "Fixed NPE issues with resources took too long to answer",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/jmeter-bzm-http2-2.0.1.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/http2-client-11.0.6.jar",
           "http2-common>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/http2-common-11.0.6.jar",
@@ -865,12 +799,10 @@
           "jetty-util>=11.0.6": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.1/jetty-util-11.0.6.jar"
         }
       },
-	  "2.0.2": {
+      "2.0.2": {
         "changes": "Improvements in performance, memory usage and connections",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jmeter-bzm-http2-2.0.2.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-client-11.0.10.jar",
           "http2-common>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/http2-common-11.0.10.jar",
@@ -884,12 +816,10 @@
           "jetty-util>=11.0.10": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.2/jetty-util-11.0.10.jar"
         }
       },
-	  "2.0.3": {
+      "2.0.3": {
         "changes": "Added support for HTTP 1.x, ALPN, multiplexing, and parallel execution. Also improvements in performance, memory and connection usage",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jmeter-bzm-http2-2.0.3.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-client-11.0.15.jar",
           "http2-common>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/http2-common-11.0.15.jar",
@@ -903,12 +833,10 @@
           "jetty-util>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.3/jetty-util-11.0.15.jar"
         }
       },
-	  "2.0.4": {
+      "2.0.4": {
         "changes": "Added support for JMeter 5.6.x",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.4/jmeter-bzm-http2-2.0.4.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.4/http2-client-11.0.15.jar",
           "http2-common>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.4/http2-common-11.0.15.jar",
@@ -922,12 +850,10 @@
           "jetty-util>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.4/jetty-util-11.0.15.jar"
         }
       },
-	  "2.0.5": {
+      "2.0.5": {
         "changes": "Fixes around iteration support in Thread Group and Loop Controllers, fixes in embedded resources, and better support for HTTP/1.",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.5/jmeter-bzm-http2-2.0.5.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "http2-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.5/http2-client-11.0.15.jar",
           "http2-common>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.5/http2-common-11.0.15.jar",
@@ -1101,7 +1027,7 @@
           "jVT220>=1.3.2": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2.1/jVT220-1.3.2.jar"
         }
       },
-	  "3.2.2": {
+      "3.2.2": {
         "changes": "Add support to continue on unknown terminal command on TN3270",
         "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2.2/jmeter-bzm-rte-3.2.2.jar",
         "libs": {
@@ -1343,7 +1269,7 @@
         "depends": ["bzm-repositories"]
       },
       "2.5": {
-        "changes": "JSON Extractor and Replacement analysis and legacy support and bug fixes",
+        "changes": "JSON Extractor and Replacement support on automatic comparison and variable detection",
         "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v2.5/jmeter-bzm-correlation-recorder-2.5.jar",
         "libs": {
           "jackson-dataformat-xml>=2.10.2": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v2.5/jackson-dataformat-xml-2.10.2.jar",


### PR DESCRIPTION
There was a mistake while copying and pasting last release as template. Changes for version 2.5 weren't updated.