### PR TITLE
Fix for Throughput Shaping Timer for unexpected test break before configured time

### DIFF
--- a/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
+++ b/plugins/tst/src/main/java/kg/apc/jmeter/timers/VariableThroughputTimer.java
@@ -85,7 +85,7 @@ public class VariableThroughputTimer
      */
     public synchronized long delay() {
         while (true) {
-            long curTimeMs = System.currentTimeMillis();
+            long curTimeMs = System.nanoTime() / 1_000_000;
             long millisSinceLastSecond = curTimeMs % 1000;
             long nowInMsRoundedAtSec = curTimeMs - millisSinceLastSecond;
             checkNextSecond(nowInMsRoundedAtSec);


### PR DESCRIPTION
We found an issue when running tests in Kubernetes environment that tests finished unexpectedly before time. For 12h tests it ends after 8h sometimes 10h. After this change where we are fetching elapsed time from JVM instead of POD OS issue is not reproducing anymore.