### PR TITLE
Fix JMeter-Plugin fails to download json-lib 

### DIFF
--- a/site/dat/repo/jmeter.json
+++ b/site/dat/repo/jmeter.json
@@ -420,7 +420,7 @@
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=org/apache/jmeter/ApacheJMeter_components/%1$s/ApacheJMeter_components-%1$s.jar",
         "libs": {
           "json-path": "http://search.maven.org/remotecontent?filepath=com/jayway/jsonpath/json-path/2.4.0/json-path-2.4.0.jar",
-          "json-lib": "http://search.maven.org/remotecontent?filepath=net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
+          "json-lib": "https://repo1.maven.org/maven2/net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
           "json-smart": "http://search.maven.org/remotecontent?filepath=net/minidev/json-smart/2.3/json-smart-2.3.jar",
           "asm": "http://search.maven.org/remotecontent?filepath=net/minidev/asm/1.0.2/asm-1.0.2.jar"
         }

--- a/site/dat/repo/jpgc-plugins.json
+++ b/site/dat/repo/jpgc-plugins.json
@@ -123,9 +123,7 @@
     "versions": {
       "0.1": {
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-dbmon/0.1/jmeter-plugins-dbmon-0.1.jar",
-        "depends": [
-          "jmeter-jdbc"
-        ],
+        "depends": ["jmeter-jdbc"],
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
         }
@@ -266,9 +264,7 @@
     "versions": {
       "0.2": {
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-jms/0.2/jmeter-plugins-jms-0.2.jar",
-        "depends": [
-          "jmeter-java"
-        ],
+        "depends": ["jmeter-java"],
         "libs": {
           "qpid-common": "https://search.maven.org/remotecontent?filepath=org/apache/qpid/qpid-common/0.20/qpid-common-0.20.jar",
           "qpid-client": "https://search.maven.org/remotecontent?filepath=org/apache/qpid/qpid-client/0.20/qpid-client-0.20.jar",
@@ -331,7 +327,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.4/jmeter-plugins-cmn-jmeter-0.4.jar",
           "json-path": "https://search.maven.org/remotecontent?filepath=com/jayway/jsonpath/json-path/2.4.0/json-path-2.4.0.jar",
-          "json-lib": "https://search.maven.org/remotecontent?filepath=net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
+          "json-lib": "https://repo1.maven.org/maven2/net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
           "json-smart": "https://search.maven.org/remotecontent?filepath=net/minidev/json-smart/2.3/json-smart-2.3.jar",
           "asm": "https://search.maven.org/remotecontent?filepath=net/minidev/asm/1.0.2/asm-1.0.2.jar"
         }
@@ -342,7 +338,7 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar",
           "json-path": "https://search.maven.org/remotecontent?filepath=com/jayway/jsonpath/json-path/2.4.0/json-path-2.4.0.jar",
-          "json-lib": "https://search.maven.org/remotecontent?filepath=net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
+          "json-lib": "https://repo1.maven.org/maven2/net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar",
           "json-smart": "https://search.maven.org/remotecontent?filepath=net/minidev/json-smart/2.3/json-smart-2.3.jar",
           "asm": "https://search.maven.org/remotecontent?filepath=net/minidev/asm/1.0.2/asm-1.0.2.jar",
           "snakeyaml": "https://search.maven.org/remotecontent?filepath=org/yaml/snakeyaml/1.21/snakeyaml-1.21.jar"
@@ -382,9 +378,7 @@
     "versions": {
       "0.1": {
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-oauth/0.1/jmeter-plugins-oauth-0.1.jar",
-        "depends": [
-          "jmeter-http"
-        ],
+        "depends": ["jmeter-http"],
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar",
           "commons-lang": "https://search.maven.org/remotecontent?filepath=commons-lang/commons-lang/2.6/commons-lang-2.6.jar"
@@ -446,9 +440,7 @@
     "helpUrl": "https://jmeter-plugins.org/wiki/RedisDataSet/",
     "vendor": "JMeter-Plugins.org",
     "markerClass": "kg.apc.jmeter.config.redis.RedisDataSet",
-    "componentClasses": [
-      "kg.apc.jmeter.config.redis.RedisDataSet"
-    ],
+    "componentClasses": ["kg.apc.jmeter.config.redis.RedisDataSet"],
     "versions": {
       "0.1": {
         "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-redis/0.1/jmeter-plugins-redis-0.1.jar",


### PR DESCRIPTION
## Issue explanation
When installing JMeter plugin v1.10 in a new fresh new JMeter(v5.6.1), JMeter Plugins requires the following dependencies to be downloaded:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/f9b4aa46-d7af-4426-9054-4e4256bae130">
When trying to comply with those requirements one faces:
<img width="354" alt="image" src="https://github.com/user-attachments/assets/6e17af6f-63b0-4c7f-b038-9e1405bb116c">
Alongside with a stacktrace that presents as follow:

```java
2024-09-18 16:48:31,909 ERROR o.j.r.PluginManager: Failed to download json-lib
org.apache.http.client.ClientProtocolException: null
	at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:839) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56) ~[httpclient-4.5.14.jar:4.5.14]
	at org.jmeterplugins.repository.JARSourceHTTP.execute(JARSourceHTTP.java:499) ~[jmeter-plugins-manager-1.10.jar:?]
	at org.jmeterplugins.repository.JARSourceHTTP.getJAR(JARSourceHTTP.java:389) ~[jmeter-plugins-manager-1.10.jar:?]
	at org.jmeterplugins.repository.PluginManager.applyChanges(PluginManager.java:167) [jmeter-plugins-manager-1.10.jar:?]
	at org.jmeterplugins.repository.PluginManagerDialog$4.run(PluginManagerDialog.java:212) [jmeter-plugins-manager-1.10.jar:?]
Caused by: org.apache.http.client.CircularRedirectException: Circular redirect to 'https://search.maven.org/remotecontent?filepath=net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar'
	at org.apache.http.impl.client.DefaultRedirectStrategy.getLocationURI(DefaultRedirectStrategy.java:193) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.DefaultRedirectStrategy.getRedirect(DefaultRedirectStrategy.java:223) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.DefaultRequestDirector.handleResponse(DefaultRequestDirector.java:1078) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:509) ~[httpclient-4.5.14.jar:4.5.14]
	at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:835) ~[httpclient-4.5.14.jar:4.5.14]
	... 6 more
```


## Solution
Configure a new download url for *json-lib* library. New url points to the repository instead of using search.maven.org.
