### PR TITLE
CorrelationRecorder v3.0

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1414,6 +1414,23 @@
         "depends": [
           "bzm-repositories"
         ]
+      },
+      "3.0": {
+        "changes": "Siebel components removed and many bug fixes!",
+        "downloadUrl": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jmeter-bzm-correlation-recorder-3.0.jar",
+        "libs": {
+          "jackson-dataformat-xml>=2.10.3": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jackson-dataformat-xml-2.10.3.jar",
+          "jackson-annotations>=2.13.3": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jackson-annotations-2.13.0.jar",
+          "jackson-databind>=2.10.3": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jackson-databind-2.10.3.jar",
+          "jackson-core>=2.13.3": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jackson-core-2.13.3.jar",
+          "jackson-module-jaxb-annotations>=2.10.3": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jackson-module-jaxb-annotations-2.10.3.jar",
+          "jmeter-bzm-commons>=0.2.1": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/jmeter-bzm-commons-0.2.1.jar",
+          "json>=20190722": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/json-20190722.jar",
+          "maven-artifact>=3.8.4": "https://github.com/Blazemeter/CorrelationRecorder/releases/download/v3.0/maven-artifact-3.8.4.jar"
+        },
+        "depends": [
+          "bzm-repositories"
+        ]
       }
     }
   },


### PR DESCRIPTION
# Auto Correlation Recorder Plugin v3.0 Release Note

We're excited to bring you the latest enhancements and features in the Auto Correlation Recorder Plugin v3.0
Here's what's new:

## Siebel removed from core

The following components were removed from the plugin
- Siebel Array JMeter Function
- Siebel Counter Correlation Replacement
- Siebel Row Correlation Extractor
- Siebel Row Id Correlation Replacement
- Siebel Row Params Correlation Replacement
The main reason this release is major one is due to the lack of backward compatibility.

However, not all are bad news. Now it's possible to access to a better Siebel correlation support by joining the [Blazemeter community](https://www.blazemeter.com/).
It's possible to use the new template and components directly from the plugin!

## Other Improvements

- Fix issue which reseted the JMeter templates.xml
- Allow to display templates description that contain custom rules despite of jar installation
- Dynamic class loader for custom extractors and replacements
- Custom extensions are now saved in lib/ext to benefit from JMeter class loading system
- Fix several issues related to apply suggestions based on a template
