### PR TITLE
Custom Thread Groups - Allow to run on JMeter lower than 5.2

### DIFF
--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractThreadStarter.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/AbstractThreadStarter.java
@@ -16,6 +16,10 @@ import org.slf4j.Logger;
 
 public abstract class AbstractThreadStarter extends Thread {
     private static final Logger log = LoggerFactory.getLogger(AbstractThreadStarter.class);
+    private static final String[] jmeterVersion =
+        JMeterUtils.getJMeterVersion().split(" ")[0].split("\\.", 3);
+    private static final int JMETER_VERSION_MAJOR = Integer.parseInt(jmeterVersion[0]);
+    private static final int JMETER_VERSION_MINOR = Integer.parseInt(jmeterVersion[1]);
     protected final ListenerNotifier notifier;
     protected final ListedHashTree threadGroupTree;
     protected final StandardJMeterEngine engine;
@@ -59,7 +63,13 @@ public abstract class AbstractThreadStarter extends Thread {
         boolean onErrorStopTestNow = owner.getOnErrorStopTestNow();
         boolean onErrorStopThread = owner.getOnErrorStopThread();
         boolean onErrorStartNextLoop = owner.getOnErrorStartNextLoop();
-        final DynamicThread jmeterThread = new DynamicThread(treeClone, this.owner, notifier, owner.getSameUser());
+        DynamicThread jmeterThread;
+        if (JMETER_VERSION_MAJOR >= 5 && JMETER_VERSION_MINOR >=2) {
+            jmeterThread =
+                new DynamicThread(treeClone, this.owner, notifier, owner.getSameUser());
+        } else {
+            jmeterThread = new DynamicThread(treeClone, this.owner, notifier);
+        }
         jmeterThread.setThreadNum((int) threadIndex);
         jmeterThread.setThreadGroup(this.owner);
         jmeterThread.setInitialContext(context);

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/DynamicThread.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/threads/DynamicThread.java
@@ -14,6 +14,9 @@ public class DynamicThread extends JMeterThread {
         super(test, monitor, note, isSameUserOnNextIteration);
     }
 
+    public DynamicThread(HashTree test, JMeterThreadMonitor monitor, ListenerNotifier note) {
+        super(test, monitor, note);
+    }
     public void setOSThread(Thread OSThread) {
         this.osThread = OSThread;
     }


### PR DESCRIPTION
The latest change made in Custom Thread Groups version 3.0 allows the new JMeterThread from JMeter 5.2 to be used in ConcurrencyThreadGroup, ArrivalsThreadGroup and FreeFormArrivalsThreadGroup, but breaks compatibility with JMeter older than 5.2.

I am making a proposal to allow the use of JMeters older than 5.2 using the old JMeterThread constructor.
This applies only to ConcurrencyThreadGroup, ArrivalsThreadGroup and FreeFormArrivalsThreadGroup.

Apologies for not realizing earlier that it was possible to incorporate this possibility, I later realized that it would be easy to incorporate it and thus surely not break the execution of those who still use JMeter lower than 5.2.

I can incorporate this "version checking" and disable the new field in the UI if necessary, although it is adding code for probably a small group of users.

I look forward to hearing what you think about this proposal.
