### PR TITLE
Custom Thread Groups v3.0

### DIFF
--- a/site/dat/repo/jpgc-plugins.json
+++ b/site/dat/repo/jpgc-plugins.json
@@ -63,6 +63,13 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
         }
+      },
+      "3.0": {
+        "changes": "Support for 'Same User On Each Iteration' on ConcurrencyThreadGroup, ArrivalsThreadGroup and FreeFormArrivalsThreadGroup",
+        "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-casutg/3.0/jmeter-plugins-casutg-3.0.jar",
+        "libs": {
+          "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
Support for 'Same User On Each Iteration' on ConcurrencyThreadGroup, ArrivalsThreadGroup and FreeFormArrivalsThreadGroup