### PR TITLE
Version 6.1 for har-convertor-jmeter-tool

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -2030,6 +2030,10 @@
 	"6.0": {
           "changes": "Add View Result Tree to view the recording xml file",
           "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v6.0/har-convertor-jmeter-plugin-6.0-jar-with-dependencies.jar"
+        },
+	"6.1": {
+          "changes": "Correct a NullPointerException when creating the Recording XML file.",
+          "downloadUrl": "https://github.com/vdaburon/har-convertor-jmeter-plugin/releases/download/v6.1/har-convertor-jmeter-plugin-6.1-jar-with-dependencies.jar"
         }
       }
    },


### PR DESCRIPTION
Version 6.1 Use new library har-to-jmeter-convertor 6.1 to correct a NullPointerException when creating the Recording XML file.