### PR TITLE
Custom Thread Groups - Add support for IteratingController implement

### DIFF
--- a/plugins/casutg/pom.xml
+++ b/plugins/casutg/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-casutg</artifactId>
-    <version>3.0</version>
+    <version>3.1</version>
 
     <name>Custom Thread Groups</name>
     <description>Custom Thread Groups</description>


### PR DESCRIPTION
Hi @undera 

It was detected that the plugin is not using the IteratingController interface and is therefore not calling the updateIterationIndex method (in VirtualUserController).

The call to this method is responsible for creating the variable in the execution context with the value of the current iteration number of the running Thread Group.
Scripts that use this variable when migrating from Thread Group to some Thread Group in this plugin fail because the current implementation does not create that variable.

It is proposed to incorporate the use of the IteratingController interface in VirtualUserController to call updateIterationIndex to create that variable, just as the native Thread Group currently does with LoopController.

For the methods to be implemented with support for this interface, ideas were taken from JMeter's LoopController implementation (in an attempt to be aligned).

I look forward to your review, as well as any suggestions or changes you think are appropriate.

Regards
David