### PR TITLE
Custom Thread Groups v3.1

### DIFF
--- a/site/dat/repo/jpgc-plugins.json
+++ b/site/dat/repo/jpgc-plugins.json
@@ -70,6 +70,13 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
         }
+      },
+      "3.1": {
+        "changes": "IteratingController support for built-in iteration variable support in JMeter 5.2+",
+        "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-casutg/3.1/jmeter-plugins-casutg-3.1.jar",
+        "libs": {
+          "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
IteratingController support for built-in iteration variable support in JMeter 5.2+

Hi @undera 
Yesterday, the PR related to version 3.1 of Custom Thread Groups was approved.
I didn't find that it's yet available in Maven.
This PR depends on the JAR being available in Maven.

I'll leave it up to you to tell me the steps to follow to have version 3.1 in production.


