### PR TITLE
Custom Thread Groups - Reporting the correct value to updateIterationIndex

### DIFF
--- a/plugins/casutg/pom.xml
+++ b/plugins/casutg/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-casutg</artifactId>
-    <version>3.1</version>
+    <version>3.1.1</version>
 
     <name>Custom Thread Groups</name>
     <description>Custom Thread Groups</description>

--- a/plugins/casutg/src/main/java/com/blazemeter/jmeter/control/VirtualUserController.java
+++ b/plugins/casutg/src/main/java/com/blazemeter/jmeter/control/VirtualUserController.java
@@ -23,7 +23,7 @@ public class VirtualUserController extends GenericController implements Iteratin
 
     @Override
     public Sampler next() {
-        updateIterationIndex(owner.getName(), (int) iterationNo);
+        updateIterationIndex();
         try {
             if (breakLoop || owner.isLimitReached()) {
                 setDone(true);
@@ -33,7 +33,7 @@ public class VirtualUserController extends GenericController implements Iteratin
                 }
                 hasArrived = true;
                 incrementLoopCount();
-                updateIterationIndex(owner.getName(), (int) iterationNo);
+                updateIterationIndex();
                 if (owner instanceof ArrivalsThreadGroup) {
                     getOwnerAsArrivals().arrivalFact(JMeterContextService.getContext().getThread(), iterationNo);
                     if (!owner.isRunning()) {
@@ -44,8 +44,14 @@ public class VirtualUserController extends GenericController implements Iteratin
             }
             return super.next();
         } finally {
-            updateIterationIndex(owner.getName(), (int) iterationNo);
+            updateIterationIndex();
         }
+    }
+
+    private void updateIterationIndex() {
+        // This controller increment prior sample and ThreadGroup controllers do the opposite
+        // We subtract one to JMeter IterationIndex to be aligned with TG (start with 0)
+        updateIterationIndex(owner.getName(), getIterCount() - 1);
     }
 
     private boolean moveToPool(JMeterThread thread) {
@@ -114,7 +120,7 @@ public class VirtualUserController extends GenericController implements Iteratin
 
     @Override
     protected int getIterCount() {
-        return (int) (iterationNo + 1);
+        return (int) (iterationNo);
     }
 
     public void startNextLoop() {


### PR DESCRIPTION
In version 3.1 of Custom Thread Groups, support for iteration variables was added.

It was reported that now that the iteration variable is reported, it doesn't follow the same pattern as ThreadGroup.
VirtualUserController has a different iteration numbering logic, which is why the first iteration is initialized with 1.
Therefore, when updateIterationIndex is called to store the iteration variable with the _idx value, it starts at 1, not 0 like ThreadGroup.

A small fix has been made to report it so that VirtualUserController reports the same way as the ThreadGroup controller (The iteration index is reported starting at zero).

It is proposed to adjust how the value is reported to updateIterationIndex so that the index used in the variables is appropriate, starting from zero.

Also fixed getIterCount to return the internal index without the increment, since VirtualUserController already internally enumerates iteration 1 as 1 and not zero (doesn't require the +1).
