### PR TITLE
Custom Thread Groups v3.1.1

### DIFF
--- a/site/dat/repo/jpgc-plugins.json
+++ b/site/dat/repo/jpgc-plugins.json
@@ -77,6 +77,13 @@
         "libs": {
           "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
         }
+      },
+      "3.1.1": {
+        "changes": "Minor fix related to IteratingController support and reported starting index",
+        "downloadUrl": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-casutg/3.1.1/jmeter-plugins-casutg-3.1.1.jar",
+        "libs": {
+          "jmeter-plugins-cmn-jmeter": "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-cmn-jmeter/0.7/jmeter-plugins-cmn-jmeter-0.7.jar"
+        }
       }
     }
   },


### PR DESCRIPTION
Minor fix related to IteratingController support and reported starting index

Hi @undera
Today, the PR related to version 3.1.1 of Custom Thread Groups was approved.

This PR is to be reviewed and executed when the maven release of Custom Thread Groups version 3.1.1 is complete.
