### PR TITLE
Blazemeter/HLSPlugin release v3.2.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -631,6 +631,25 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.2.1": {
+        "changes": "BlazeMeter rebranding",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jmeter-bzm-hls-3.2.1.jar",
+        "libs": {
+          "hlsparserj>=1.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/hlsparserj-1.0.1.jar",
+          "jackson-annotations>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jackson-annotations-2.11.0.jar",
+          "jackson-core>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jackson-core-2.10.0.jar",
+          "jackson-databind>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jackson-databind-2.11.0.jar",
+          "jackson-dataformat-xml>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jackson-dataformat-xml-2.10.0.jar",
+          "jackson-module-jaxb-annotations>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jackson-module-jaxb-annotations-2.10.0.jar",
+          "jaxb-api>=2.3.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/jaxb-api-2.3.1.jar",
+          "mpd-tools>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/mpd-tools-release-0.8-jdk8.jar",
+          "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/stax2-api-4.2.jar",
+          "woodstox-core>=6.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2.1/woodstox-core-6.0.1.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
# What's new:
- BlazeMeter rebranding

## What's Changed
* Add JMeter Plugin publish action by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/34
* Remove testing upstream from automatic release deployment by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/36
* Release v3.2.1 by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/35


**Full Changelog**: https://github.com/Blazemeter/HLSPlugin/compare/v3.2...v3.2.1