### PR TITLE
Blazemeter/CitrixPlugin release v0.7.8

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1656,6 +1656,16 @@
           "jmeter-components",
           "jmeter-http"
         ]
+      },
+      "0.7.8": {
+        "changes": "BlazeMeter rebranding",
+        "downloadUrl": "https://github.com/Blazemeter/CitrixPlugin/releases/download/0.7.8/citrix-jmeter-0.7.8.jar",
+        "libs": {},
+        "depends": [
+          "jmeter-core",
+          "jmeter-components",
+          "jmeter-http"
+        ]
       }
     }
   }


### PR DESCRIPTION
Release 0.7.8

**Enhancements:**

- Blazemeter icon updated (via jmeter-bzm-commons update)

- Fixed a Null Pointer Exception that prevented the plugin from being used in batch mode.

- The citrix_client_name variable can now be used in both recording and batch modes.