### PR TITLE
Enhancements Jmeter autostop plugin

### DIFF
--- a/plugins/autostop/pom.xml
+++ b/plugins/autostop/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-autostop</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
 
     <name>Autostop plugin</name>
     <description>Autostop plugin</description>

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
@@ -8,11 +8,24 @@ import org.apache.jmeter.reporters.AbstractListenerElement;
 import org.apache.jmeter.samplers.Remoteable;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleListener;
+import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestStateListener;
+import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.SamplingStatCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.functions.AbstractFunction;
+
+
+
 
 import java.io.Serializable;
 import java.net.DatagramPacket;
@@ -32,13 +45,20 @@ public class AutoStop
     private final static String ERROR_RATE_SECS = "error_rate_length";
     private final static String RESPONSE_LATENCY = "avg_response_latency";
     private final static String RESPONSE_LATENCY_SECS = "avg_response_latency_length";
+    private final static String PERCENTILE_RESPONSE_TIME = "percentile_response_time";
+    private final static String PERCENTILE_RESPONSE_TIME_SECS ="percentile_response_time_secs";
+    private final static String PERCENTILE_VALUE = "percentile_value";
+    private final static String CUSTOM_VALIDATION_DURATION = "custom_validation_duration";
     private long curSec = 0L;
     private GraphPanelChartAverageElement avgRespTime = new GraphPanelChartAverageElement();
     private GraphPanelChartAverageElement avgRespLatency = new GraphPanelChartAverageElement();
     private GraphPanelChartAverageElement errorRate = new GraphPanelChartAverageElement();
+    SamplingStatCalculator statCalc = new SamplingStatCalculator();
     private long respTimeExceededStart = 0;
     private long errRateExceededStart = 0;
     private long respLatencyExceededStart = 0;
+    private long percentileRespTimeExceededStart = 0;
+    private long customValidationExceededStart = 0;
     private int stopTries = 0;
     //optimization: not convert String to number for each sample
     private int testValueRespTime = 0;
@@ -47,6 +67,15 @@ public class AutoStop
     private int testValueRespLatencySec = 0;
     private float testValueError = 0;
     private int testValueErrorSec = 0;
+    private int testValuePercentileRespTime = 0;
+    private int testValuePercentileRespTimeSec = 0;
+    private float testPercentileValue = 0;
+    private int percentileResponseTime = 0;
+    private String testExpectedValue = "true";
+    private String testActualValue = "false";
+    private int testValueCustomSec = 180;
+    private boolean skipIter = false;
+
 
     public AutoStop() {
         super();
@@ -54,6 +83,8 @@ public class AutoStop
 
     @Override
     public void sampleOccurred(SampleEvent se) {
+        SampleResult sr = se.getResult();
+        statCalc.addSample(sr);
         long sec = System.currentTimeMillis() / 1000;
 
         if (curSec != sec) {
@@ -74,7 +105,7 @@ public class AutoStop
             if (testValueRespLatency > 0) {
                 //log.debug("Avg resp time: "+avgRespTime.getValue());
                 if (avgRespLatency.getValue() > testValueRespLatency) {
-                    //log.debug((sec - respTimeExceededStart)+" "+getResponseTimeSecsAsInt());
+                    //log.debug((sec - respTimeExceededStart)+" "+getResponseLatencySecsAsInt());
                     if (sec - respLatencyExceededStart >= testValueRespLatencySec) {
                         log.info("Average Latency Time is more than " + getResponseLatency() + " for " + getResponseLatencySecs() + "s. Auto-shutdown test...");
                         System.out.println("AutoStop - Average Latency Time is more than " + getResponseLatency() + " for " + getResponseLatencySecs() + "s. Auto-shutdown test...");
@@ -99,10 +130,25 @@ public class AutoStop
                 }
             }
 
+            if(testValuePercentileRespTime > 0) {
+                log.info(testPercentileValue+"Percentile Response >"+testValuePercentileRespTime+"until"+testValuePercentileRespTimeSec+"currentValue"+percentileResponseTime);
+                log.info(testActualValue+">>"+testExpectedValue+">>"+skipIter+">>"+testValueCustomSec);
+                if(percentileResponseTime > testValuePercentileRespTime) {
+                    log.info((sec - percentileRespTimeExceededStart)+" "+getPercentileResponseTimeSecsAsInt());
+                    if (sec - percentileRespTimeExceededStart >= testValuePercentileRespTimeSec) {
+                        log.info(testPercentileValue+"Percentile Response more than " + getPercentileResponseTime() + " for " + getPercentileResponseTimeSecs() + "s. Auto-shutdown test...");
+                        stopTest();
+                    }
+                } else {
+                    percentileRespTimeExceededStart = sec;
+                }
+            }
+
             curSec = sec;
             avgRespTime = new GraphPanelChartAverageElement();
             avgRespLatency = new GraphPanelChartAverageElement();
             errorRate = new GraphPanelChartAverageElement();
+            percentileResponseTime = statCalc.getPercentPoint(testPercentileValue).intValue();
         }
 
         avgRespTime.add(se.getResult().getTime());
@@ -130,6 +176,8 @@ public class AutoStop
         errRateExceededStart = 0;
         respTimeExceededStart = 0;
         respLatencyExceededStart = 0;
+        percentileRespTimeExceededStart = 0;
+        customValidationExceededStart = 0;
 
         //init test values
         testValueError = getErrorRateAsFloat();
@@ -138,6 +186,11 @@ public class AutoStop
         testValueRespLatencySec = getResponseLatencySecsAsInt();
         testValueRespTime = getResponseTimeAsInt();
         testValueRespTimeSec = getResponseTimeSecsAsInt();
+        testValuePercentileRespTime = getPercentileResponseTimeAsInt();
+        testValuePercentileRespTimeSec = getPercentileResponseTimeSecsAsInt();
+        testPercentileValue = getPercentileValueAsFloat();
+        testValueCustomSec = getCustomValidationDurationAsInt();
+
     }
 
     @Override
@@ -152,6 +205,14 @@ public class AutoStop
     @Override
     public void testEnded(String string) {
     }
+
+    void setPercentileResponseTime(String text) { setProperty(PERCENTILE_RESPONSE_TIME, text); }
+
+    void setPercentileResponseTimeSecs(String text) { setProperty(PERCENTILE_RESPONSE_TIME_SECS, text); }
+
+    void setPercentileValue(String text) { setProperty(PERCENTILE_VALUE, text); }
+
+    void setCustomValidationDuration(String text) { setProperty(CUSTOM_VALIDATION_DURATION, text); }
 
     void setResponseTime(String text) {
         setProperty(RESPONSE_TIME, text);
@@ -177,6 +238,14 @@ public class AutoStop
         setProperty(ERROR_RATE_SECS, text);
     }
 
+    String getPercentileResponseTime() { return getPropertyAsString(PERCENTILE_RESPONSE_TIME); }
+
+    String getPercentileResponseTimeSecs() { return getPropertyAsString(PERCENTILE_RESPONSE_TIME_SECS); }
+
+    String getPercentileValue() { return getPropertyAsString(PERCENTILE_VALUE); }
+
+    String getCustomValidationDuration() { return getPropertyAsString(CUSTOM_VALIDATION_DURATION); }
+
     String getResponseTime() {
         return getPropertyAsString(RESPONSE_TIME);
     }
@@ -199,6 +268,50 @@ public class AutoStop
 
     String getErrorRateSecs() {
         return getPropertyAsString(ERROR_RATE_SECS);
+    }
+
+    private int getPercentileResponseTimeAsInt() {
+        int res = 0;
+        try {
+            res = Integer.parseInt(getPercentileResponseTime());
+        } catch (NumberFormatException e) {
+            log.error("Wrong response time: " + getPercentileResponseTime(), e);
+            setPercentileResponseTime("0");
+        }
+        return res;
+    }
+
+    private int getPercentileResponseTimeSecsAsInt() {
+        int res = 0;
+        try {
+            res = Integer.parseInt(getPercentileResponseTimeSecs());
+        } catch (NumberFormatException e) {
+            log.error("Wrong response time period: " + getPercentileResponseTimeSecs(), e);
+            setPercentileResponseTimeSecs("1");
+        }
+        return res > 0 ? res : 1;
+    }
+
+    private int getCustomValidationDurationAsInt() {
+        int res = 0;
+        try {
+            res = Integer.parseInt(getCustomValidationDuration());
+        } catch (NumberFormatException e) {
+            log.error("Wrong time period: " + getCustomValidationDuration(), e);
+            setCustomValidationDuration("1");
+        }
+        return res > 0 ? res : 1;
+    }
+
+    private float getPercentileValueAsFloat() {
+        float res = 0;
+        try {
+            res = Float.parseFloat(getPercentileValue()) / 100;
+        } catch (NumberFormatException e) {
+            log.error("Wrong Percentile Value: " + getPercentileValue(), e);
+            setPercentileValue("1");
+        }
+        return res > 0 ? res : 1;
     }
 
     private int getResponseTimeAsInt() {

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
@@ -131,10 +131,10 @@ public class AutoStop
             }
 
             if(testValuePercentileRespTime > 0) {
-                log.info(testPercentileValue+"Percentile Response >"+testValuePercentileRespTime+"until"+testValuePercentileRespTimeSec+"currentValue"+percentileResponseTime);
-                log.info(testActualValue+">>"+testExpectedValue+">>"+skipIter+">>"+testValueCustomSec);
+                log.debug(testPercentileValue+"Percentile Response >"+testValuePercentileRespTime+"until"+testValuePercentileRespTimeSec+"currentValue"+percentileResponseTime);
+                log.debug(testActualValue+">>"+testExpectedValue+">>"+skipIter+">>"+testValueCustomSec);
                 if(percentileResponseTime > testValuePercentileRespTime) {
-                    log.info((sec - percentileRespTimeExceededStart)+" "+getPercentileResponseTimeSecsAsInt());
+                    log.dubeg((sec - percentileRespTimeExceededStart)+" "+getPercentileResponseTimeSecsAsInt());
                     if (sec - percentileRespTimeExceededStart >= testValuePercentileRespTimeSec) {
                         log.info(testPercentileValue+"Percentile Response more than " + getPercentileResponseTime() + " for " + getPercentileResponseTimeSecs() + "s. Auto-shutdown test...");
                         stopTest();

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/AutoStop.java
@@ -83,8 +83,6 @@ public class AutoStop
 
     @Override
     public void sampleOccurred(SampleEvent se) {
-        SampleResult sr = se.getResult();
-        statCalc.addSample(sr);
         long sec = System.currentTimeMillis() / 1000;
 
         if (curSec != sec) {
@@ -131,10 +129,12 @@ public class AutoStop
             }
 
             if(testValuePercentileRespTime > 0) {
-                log.debug(testPercentileValue+"Percentile Response >"+testValuePercentileRespTime+"until"+testValuePercentileRespTimeSec+"currentValue"+percentileResponseTime);
-                log.debug(testActualValue+">>"+testExpectedValue+">>"+skipIter+">>"+testValueCustomSec);
+                SampleResult sr = se.getResult();
+                statCalc.addSample(sr);
+                // log.debug(testPercentileValue+"Percentile Response >"+testValuePercentileRespTime+"until"+testValuePercentileRespTimeSec+"currentValue"+percentileResponseTime);
+                // log.debug(testActualValue+">>"+testExpectedValue+">>"+skipIter+">>"+testValueCustomSec);
                 if(percentileResponseTime > testValuePercentileRespTime) {
-                    log.dubeg((sec - percentileRespTimeExceededStart)+" "+getPercentileResponseTimeSecsAsInt());
+                    //log.debug((sec - percentileRespTimeExceededStart)+" "+getPercentileResponseTimeSecsAsInt());
                     if (sec - percentileRespTimeExceededStart >= testValuePercentileRespTimeSec) {
                         log.info(testPercentileValue+"Percentile Response more than " + getPercentileResponseTime() + " for " + getPercentileResponseTimeSecs() + "s. Auto-shutdown test...");
                         stopTest();

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.form
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.1" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.7" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.form
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.7" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <Properties>
@@ -18,7 +18,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-14,0,0,2,-75"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,38,0,0,2,-68"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -193,7 +193,7 @@
     <Container class="javax.swing.JPanel" name="jPanel3">
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
+          <GridBagConstraints gridX="0" gridY="10" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
         </Constraint>
       </Constraints>
 
@@ -225,5 +225,156 @@
         </Constraint>
       </Constraints>
     </Component>
+    <Component class="javax.swing.JLabel" name="jLabel13">
+      <Properties>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+          <Font name="Tahoma" size="10" style="0"/>
+        </Property>
+        <Property name="text" type="java.lang.String" value="OR"/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="6" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="10" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel20">
+      <Properties>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+          <Font name="Tahoma" size="10" style="0"/>
+        </Property>
+        <Property name="text" type="java.lang.String" value="OR"/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="8" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="10" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Container class="javax.swing.JPanel" name="jPanel5">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="7" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="jLabelBulletPercentile">
+          <Properties>
+            <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
+              <Image iconType="3" name="/kg/apc/jmeter/reporters/bulletGreen.png"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldPercentileValue">
+          <Properties>
+            <Property name="columns" type="int" value="2"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel14">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="th Percentile Response time is greater than"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldPercentileRespTime">
+          <Properties>
+            <Property name="columns" type="int" value="7"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel15">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="ms for"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldPercentileRespTimeSec">
+          <Properties>
+            <Property name="columns" type="int" value="5"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel16">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="seconds"/>
+          </Properties>
+        </Component>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="jPanel6">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="9" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="jLabelBulletCustomValidation">
+          <Properties>
+            <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
+              <Image iconType="3" name="/kg/apc/jmeter/reporters/bulletGreen.png"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel17">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Custom Validation ( Expected = Actual)"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldExpectedValue">
+          <Properties>
+            <Property name="columns" type="int" value="5"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[30, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel18">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="="/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldActualValue">
+          <Properties>
+            <Property name="columns" type="int" value="5"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel19">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="observed for"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JTextField" name="jTextFieldCustomDuration">
+          <Properties>
+            <Property name="columns" type="int" value="5"/>
+            <Property name="horizontalAlignment" type="int" value="4"/>
+            <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[100, 20]"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="jLabel21">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="seconds"/>
+          </Properties>
+        </Component>
+      </SubComponents>
+    </Container>
   </SubComponents>
 </Form>

--- a/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.java
+++ b/plugins/autostop/src/main/java/kg/apc/jmeter/reporters/JAutoStopPanel.java
@@ -16,7 +16,10 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         registerJTextfieldForValidation(jTextFieldRespLatencySec, false);
         registerJTextfieldForValidation(jTextFieldRespTime, false);
         registerJTextfieldForValidation(jTextFieldRespTimeSec, false);
-
+        registerJTextfieldForValidation(jTextFieldPercentileRespTime, false);
+        registerJTextfieldForValidation(jTextFieldPercentileRespTimeSec, false);
+        registerJTextfieldForValidation(jTextFieldPercentileValue, false);
+        registerJTextfieldForValidation(jTextFieldCustomDuration, false);
         initFields();
     }
 
@@ -27,6 +30,10 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         jTextFieldErrorSec.setText(testElement.getErrorRateSecs());
         jTextFieldRespLatency.setText(testElement.getResponseLatency());
         jTextFieldRespLatencySec.setText(testElement.getResponseLatencySecs());
+        jTextFieldPercentileRespTime.setText(testElement.getPercentileResponseTime());
+        jTextFieldPercentileRespTimeSec.setText(testElement.getPercentileResponseTimeSecs());
+        jTextFieldPercentileValue.setText(testElement.getPercentileValue());
+        jTextFieldCustomDuration.setText(testElement.getCustomValidationDuration());
     }
 
     public void modifyTestElement(AutoStop testElement) {
@@ -36,6 +43,10 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         testElement.setErrorRateSecs(jTextFieldErrorSec.getText());
         testElement.setResponseLatency(jTextFieldRespLatency.getText());
         testElement.setResponseLatencySecs(jTextFieldRespLatencySec.getText());
+        testElement.setPercentileResponseTime(jTextFieldPercentileRespTime.getText());
+        testElement.setPercentileResponseTimeSecs(jTextFieldPercentileRespTimeSec.getText());
+        testElement.setPercentileValue(jTextFieldPercentileValue.getText());
+        testElement.setCustomValidationDuration(jTextFieldCustomDuration.getText());
     }
 
     public final void initFields() {
@@ -45,6 +56,9 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         jTextFieldErrorSec.setText("10");
         jTextFieldRespLatency.setText("5000");
         jTextFieldRespLatencySec.setText("10");
+        jTextFieldPercentileRespTime.setText("15000");
+        jTextFieldPercentileRespTimeSec.setText("10");
+        jTextFieldPercentileValue.setText("90");
     }
 
     private int getIntValue(JTextField tf) {
@@ -80,6 +94,7 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         jLabelBulletError.setEnabled(getFloatValue(jTextFieldError) > 0 || isVariableValue(jTextFieldError));
         jLabelBulletRespTime.setEnabled(getIntValue(jTextFieldRespTime) > 0 || isVariableValue(jTextFieldRespTime));
         jLabelBulletLatency.setEnabled(getIntValue(jTextFieldRespLatency) > 0 || isVariableValue(jTextFieldRespLatency));
+        jLabelBulletPercentile.setEnabled(getIntValue(jTextFieldPercentileRespTime) > 0 || isVariableValue(jTextFieldPercentileRespTime));
     }
 
     private void setJTextFieldColor(final JTextField tf, boolean isFloat) {
@@ -150,6 +165,22 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         jPanel3 = new javax.swing.JPanel();
         jLabel8 = new javax.swing.JLabel();
         jLabel9 = new javax.swing.JLabel();
+        jLabel13 = new javax.swing.JLabel();
+        jLabel20 = new javax.swing.JLabel();
+        jPanel5 = new javax.swing.JPanel();
+        jLabelBulletPercentile = new javax.swing.JLabel();
+        jTextFieldPercentileValue = new javax.swing.JTextField();
+        jLabel14 = new javax.swing.JLabel();
+        jTextFieldPercentileRespTime = new javax.swing.JTextField();
+        jLabel15 = new javax.swing.JLabel();
+        jTextFieldPercentileRespTimeSec = new javax.swing.JTextField();
+        jLabel16 = new javax.swing.JLabel();
+        jPanel6 = new javax.swing.JPanel();
+        jLabelBulletCustomValidation = new javax.swing.JLabel();
+        jLabel17 = new javax.swing.JLabel();
+        jLabel19 = new javax.swing.JLabel();
+        jTextFieldCustomDuration = new javax.swing.JTextField();
+        jLabel21 = new javax.swing.JLabel();
 
         setBorder(javax.swing.BorderFactory.createTitledBorder("Test Shutdown Criteria"));
         setLayout(new java.awt.GridBagLayout());
@@ -250,13 +281,13 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         add(jPanel4, gridBagConstraints);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 10;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         add(jPanel3, gridBagConstraints);
 
-        jLabel8.setFont(new java.awt.Font("Tahoma", 0, 10));
+        jLabel8.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jLabel8.setText("OR");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -265,7 +296,7 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         gridBagConstraints.insets = new java.awt.Insets(0, 10, 0, 0);
         add(jLabel8, gridBagConstraints);
 
-        jLabel9.setFont(new java.awt.Font("Tahoma", 0, 10));
+        jLabel9.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         jLabel9.setText("OR");
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
@@ -273,6 +304,63 @@ public class JAutoStopPanel extends javax.swing.JPanel {
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 10, 0, 0);
         add(jLabel9, gridBagConstraints);
+
+        jLabel13.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
+        jLabel13.setText("OR");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 10, 0, 0);
+        add(jLabel13, gridBagConstraints);
+
+        jLabel20.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 8;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 10, 0, 0);
+        add(jLabel20, gridBagConstraints);
+
+        jLabelBulletPercentile.setIcon(new javax.swing.ImageIcon(getClass().getResource("/kg/apc/jmeter/reporters/bulletGreen.png"))); // NOI18N
+        jPanel5.add(jLabelBulletPercentile);
+
+        jTextFieldPercentileValue.setColumns(2);
+        jTextFieldPercentileValue.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        jTextFieldPercentileValue.setMaximumSize(new java.awt.Dimension(100, 20));
+        jPanel5.add(jTextFieldPercentileValue);
+
+        jLabel14.setText("th Percentile Response time is greater than");
+        jPanel5.add(jLabel14);
+
+        jTextFieldPercentileRespTime.setColumns(7);
+        jTextFieldPercentileRespTime.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        jTextFieldPercentileRespTime.setMaximumSize(new java.awt.Dimension(100, 20));
+        jPanel5.add(jTextFieldPercentileRespTime);
+
+        jLabel15.setText("ms for");
+        jPanel5.add(jLabel15);
+
+        jTextFieldPercentileRespTimeSec.setColumns(5);
+        jTextFieldPercentileRespTimeSec.setHorizontalAlignment(javax.swing.JTextField.RIGHT);
+        jTextFieldPercentileRespTimeSec.setMaximumSize(new java.awt.Dimension(100, 20));
+        jPanel5.add(jTextFieldPercentileRespTimeSec);
+
+        jLabel16.setText("seconds");
+        jPanel5.add(jLabel16);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 7;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        add(jPanel5, gridBagConstraints);
+
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 9;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        add(jPanel6, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
 
@@ -281,7 +369,16 @@ public class JAutoStopPanel extends javax.swing.JPanel {
     private javax.swing.JLabel jLabel10;
     private javax.swing.JLabel jLabel11;
     private javax.swing.JLabel jLabel12;
+    private javax.swing.JLabel jLabel13;
+    private javax.swing.JLabel jLabel14;
+    private javax.swing.JLabel jLabel15;
+    private javax.swing.JLabel jLabel16;
+    private javax.swing.JLabel jLabel17;
+    private javax.swing.JLabel jLabel18;
+    private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel20;
+    private javax.swing.JLabel jLabel21;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel5;
@@ -289,15 +386,23 @@ public class JAutoStopPanel extends javax.swing.JPanel {
     private javax.swing.JLabel jLabel7;
     private javax.swing.JLabel jLabel8;
     private javax.swing.JLabel jLabel9;
+    private javax.swing.JLabel jLabelBulletCustomValidation;
     private javax.swing.JLabel jLabelBulletError;
     private javax.swing.JLabel jLabelBulletLatency;
+    private javax.swing.JLabel jLabelBulletPercentile;
     private javax.swing.JLabel jLabelBulletRespTime;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel2;
     private javax.swing.JPanel jPanel3;
     private javax.swing.JPanel jPanel4;
+    private javax.swing.JPanel jPanel5;
+    private javax.swing.JPanel jPanel6;
+    private javax.swing.JTextField jTextFieldCustomDuration;
     private javax.swing.JTextField jTextFieldError;
     private javax.swing.JTextField jTextFieldErrorSec;
+    private javax.swing.JTextField jTextFieldPercentileRespTime;
+    private javax.swing.JTextField jTextFieldPercentileRespTimeSec;
+    private javax.swing.JTextField jTextFieldPercentileValue;
     private javax.swing.JTextField jTextFieldRespLatency;
     private javax.swing.JTextField jTextFieldRespLatencySec;
     private javax.swing.JTextField jTextFieldRespTime;

--- a/plugins/autostop/src/test/java/kg/apc/jmeter/reporters/AutoStopTest.java
+++ b/plugins/autostop/src/test/java/kg/apc/jmeter/reporters/AutoStopTest.java
@@ -42,6 +42,8 @@ public class AutoStopTest {
         instance.setResponseTime("0");
         instance.setErrorRate("60.6");
         instance.setErrorRateSecs("3");
+        instance.setPercentileValue("90");
+        instance.setPercentileResponseTimeSecs("10");
         instance.sampleOccurred(se);
         for (int n = 0; n < 5; n++) {
             synchronized (this) {
@@ -196,6 +198,51 @@ public class AutoStopTest {
         AutoStop instance = new AutoStop();
         String expResult = "";
         String result = instance.getResponseLatencySecs();
+        assertEquals(expResult, result);
+    }
+
+    public void testSetPercentileResponseTime() {
+        System.out.println("setPercentileResponseTime");
+        String text = "";
+        AutoStop instance = new AutoStop();
+        instance.setPercentileResponseTime(text);
+    }
+
+    public void testSetPercentileResponseTimeSecs() {
+        System.out.println("setPercentileResponseTimeSecs");
+        String text = "";
+        AutoStop instance = new AutoStop();
+        instance.setPercentileResponseTimeSecs(text);
+    }
+
+    public void testSetPercentileValue() {
+        System.out.println("setPercentileValue");
+        String text = "";
+        AutoStop instance = new AutoStop();
+        instance.setPercentileValue(text);
+    }
+
+    public void testGetPercentileResponseTime() {
+        System.out.println("getPercentileResponseTime");
+        AutoStop instance = new AutoStop();
+        String expResult = "";
+        String result = instance.getPercentileResponseTime();
+        assertEquals(expResult, result);
+    }
+
+    public void testGetPercentileResponseTimeSecs() {
+        System.out.println("getPercentileResponseTimeSecs");
+        AutoStop instance = new AutoStop();
+        String expResult = "";
+        String result = instance.getPercentileResponseTimeSecs();
+        assertEquals(expResult, result);
+    }
+
+    public void testGetPercentileValue() {
+        System.out.println("getPercentileValue");
+        AutoStop instance = new AutoStop();
+        String expResult = "";
+        String result = instance.getPercentileValue();
         assertEquals(expResult, result);
     }
 }

--- a/site/dat/wiki/Contributors.wiki
+++ b/site/dat/wiki/Contributors.wiki
@@ -24,3 +24,4 @@ Everyone who provided pull request or other contribution, deserves mentioning on
   * Pascal Treilhes - added connection resilience to [JMXMon]
   * Ori Marko - Add caseFormat function to [Custom JMeter Function]
   * Mohamed Ibrahim - GCP PubSub plugin, DI-KafkaMeter plugin, Extended CSV dataset config plugin, Couchbase Plugin
+  * Venkatesh T - AutoStop Plugin Enhancements


### PR DESCRIPTION
Added auto-stop feature based on percentile value for response time. 
Considering micro-services, this feature is helpful for latency sensitive application's where P95 and P99 are used to determine SLA breeches and stop the load automatically with the help of this plugin