### PR TITLE
Blazemeter/jmeter-debugger release v0.6.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -3,7 +3,7 @@
     "id": "blazemeter-debugger",
     "name": "BlazeMeter Step-by-step Debugger",
     "description": "This plugin enables step-by-step debugging of JMeter scripts",
-    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/jmeter-debugger/master/src/main/resources/com/blazemeter/jmeter/debugger/logo.png",
+    "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/jmeter-bzm-commons/refs/heads/master/src/main/resources/light-theme/blazemeter-by-perforce-logo.png",
     "helpUrl": "https://github.com/Blazemeter/jmeter-debugger",
     "vendor": "BlazeMeter.com",
     "markerClass": "com.blazemeter.jmeter.debugger.engine.Debugger",

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -46,6 +46,16 @@
         "depends": [
           "jmeter-core"
         ]
+      },
+      "0.6.1": {
+        "changes": "BlazeMeter rebranding",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-debugger/releases/download/0.6.1/jmeter-debugger-0.6.1.jar",
+        "libs": {
+          "jmeter-bzm-commons>=0.2.4": "https://github.com/Blazemeter/jmeter-debugger/releases/download/0.6.1/jmeter-bzm-commons-0.2.4.jar"
+        },
+        "depends": [
+          "jmeter-core"
+        ]
       }
     }
   },


### PR DESCRIPTION
## What's Changed
* Bump log4j-core from 2.8.2 to 2.15.0 by @dependabot[bot] in https://github.com/Blazemeter/jmeter-debugger/pull/16
* Apply blazemeter rebranding by @Baraujo25 in https://github.com/Blazemeter/jmeter-debugger/pull/23

## New Contributors
* @dependabot[bot] made their first contribution in https://github.com/Blazemeter/jmeter-debugger/pull/16
* @Baraujo25 made their first contribution in https://github.com/Blazemeter/jmeter-debugger/pull/23

**Full Changelog**: https://github.com/Blazemeter/jmeter-debugger/compare/0.6...0.6.1