### PR TITLE
Fix: MkDocs only processes markdown, not all of dat/

### DIFF
--- a/prepare-upload.sh
+++ b/prepare-upload.sh
@@ -19,13 +19,15 @@ cp -r examples upload/img/
 # Merge repo JSON files into single file
 python merge_repo.py
 
+# Non-MkDocs site files
+cp -r site/dat upload/
+cp -r site/files upload/ 2>/dev/null || true
+
 # PHP for /repo/ endpoint (stays dynamic)
 cp site/index.php upload/
 cp site/cfg.php upload/
 cp site/composer.json upload/
 cp -r site/JPGC upload/
-cp site/dat/out.xml upload/dat/
-cp -r site/files upload/ 2>/dev/null || true
 
 php --version
 curl -sS https://getcomposer.org/installer | php

--- a/prepare-upload.sh
+++ b/prepare-upload.sh
@@ -19,8 +19,10 @@ cp -r examples upload/img/
 # Merge repo JSON files into single file
 python merge_repo.py
 
-# Non-MkDocs site files
-cp -r site/dat upload/
+# PWE data files for /repo/ endpoint
+mkdir -p upload/dat
+cp site/dat/out.xml upload/dat/
+cp -r site/dat/repo upload/dat/
 cp -r site/files upload/ 2>/dev/null || true
 
 # PHP for /repo/ endpoint (stays dynamic)

--- a/site/build.sh
+++ b/site/build.sh
@@ -3,13 +3,20 @@ set -e
 
 cd "$(dirname "$0")"
 
+# Assemble MkDocs source with only markdown files
+rm -rf .mkdocs_src
+mkdir -p .mkdocs_src/wiki .mkdocs_src/install
+cp dat/wiki/*.md .mkdocs_src/wiki/
+cp dat/install/Install.md .mkdocs_src/install/
+cp dat/index.md dat/catalogue.md dat/stats.md .mkdocs_src/
+
 mkdocs build --clean
+
+rm -rf .mkdocs_src
 
 # Static assets not managed by MkDocs
 cp robots.txt build/
 cp favicon.ico build/ 2>/dev/null || true
 cp -r img build/
-mkdir -p build/dat/stats
-cp -r dat/repo build/dat/
 
 echo "Build complete: build/"

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: JMeter-Plugins.org
 site_url: https://jmeter-plugins.org/
 site_description: Custom plugins for Apache JMeter
 
-docs_dir: dat
+docs_dir: .mkdocs_src
 site_dir: build
 
 use_directory_urls: true


### PR DESCRIPTION
## Summary
- MkDocs was using `docs_dir: dat` which copied everything (repo JSONs, out.xml, wiki files, etc.) into build output
- Now build.sh assembles a temp `.mkdocs_src/` with only .md files
- `prepare-upload.sh` copies `dat/` separately for PHP/PWE

🤖 Generated with [Claude Code](https://claude.com/claude-code)