### PR TITLE
added new browser performance metric plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -25,9 +25,7 @@
 {                                                                                                                                                                                                                                
   "id": "io.github.sagaraggarwal86-bpm-jmeter-plugin",                                                                                                                                                                         
   "name": "BPM — Browser Performance Metrics",                                                                                                                                                                                 
-  "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance 
-Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with
-minimal impact on JMeter thread performance.",
+  "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with minimal impact on JMeter thread performance.",
   "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/BPM-jmeter-plugin/v1.0.0/docs/Image.jpg",
   "helpUrl": "https://github.com/sagaraggarwal86/BPM-jmeter-plugin/blob/v1.0.0/README.md",
   "vendor": "Sagar Aggarwal",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -23,6 +23,25 @@
 	}
 },
   {
+    "id": "io.github.sagaraggarwal86-bpm-jmeter-plugin",
+    "name": "BPM — Browser Performance Metrics",
+    "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with zero test-run overhead.",
+    "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/BPM-jmeter-plugin/main/docs/Image.jpg",
+    "helpUrl": "https://github.com/sagaraggarwal86/BPM-jmeter-plugin/blob/main/README.md",
+    "vendor": "Sagar Aggarwal",
+    "markerClass": "io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
+    "componentClasses": [
+      "io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
+      "io.github.sagaraggarwal86.jmeter.bpm.gui.BpmListenerGui"
+    ],
+    "versions": {
+      "1.0.0": {
+        "changes": "Initial release",
+        "downloadUrl": "https://repo1.maven.org/maven2/io/github/sagaraggarwal86/bpm-jmeter-plugin/1.0.0/bpm-jmeter-plugin-1.0.0.jar"
+      }
+    }
+  },
+  {
     "id": "ssh-sampler",
     "name": "SSH Protocol Support",
     "description": "",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -22,25 +22,27 @@
       }
 	}
 },
-  {
-    "id": "io.github.sagaraggarwal86-bpm-jmeter-plugin",
-    "name": "BPM — Browser Performance Metrics",
-    "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with zero test-run overhead.",
-    "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/BPM-jmeter-plugin/main/docs/Image.jpg",
-    "helpUrl": "https://github.com/sagaraggarwal86/BPM-jmeter-plugin/blob/main/README.md",
-    "vendor": "Sagar Aggarwal",
-    "markerClass": "io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
-    "componentClasses": [
-      "io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
-      "io.github.sagaraggarwal86.jmeter.bpm.gui.BpmListenerGui"
-    ],
-    "versions": {
-      "1.0.0": {
-        "changes": "Initial release",
-        "downloadUrl": "https://repo1.maven.org/maven2/io/github/sagaraggarwal86/bpm-jmeter-plugin/1.0.0/bpm-jmeter-plugin-1.0.0.jar"
-      }
-    }
-  },
+{                                                                                                                                                                                                                                
+  "id": "io.github.sagaraggarwal86-bpm-jmeter-plugin",                                                                                                                                                                         
+  "name": "BPM — Browser Performance Metrics",                                                                                                                                                                                 
+  "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance 
+Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with
+minimal impact on JMeter thread performance.",
+  "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/BPM-jmeter-plugin/v1.0.0/docs/Image.jpg",
+  "helpUrl": "https://github.com/sagaraggarwal86/BPM-jmeter-plugin/blob/v1.0.0/README.md",
+  "vendor": "Sagar Aggarwal",
+  "markerClass": "io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
+  "componentClasses": [
+	"io.github.sagaraggarwal86.jmeter.bpm.core.BpmListener",
+	"io.github.sagaraggarwal86.jmeter.bpm.gui.BpmListenerGui"
+  ],
+  "versions": {
+	"1.0.0": {
+	  "changes": "Initial release",
+	  "downloadUrl": "https://repo1.maven.org/maven2/io/github/sagaraggarwal86/bpm-jmeter-plugin/1.0.0/bpm-jmeter-plugin-1.0.0.jar"
+	}
+  }
+},
   {
     "id": "ssh-sampler",
     "name": "SSH Protocol Support",


### PR DESCRIPTION
 Hi,                                                                                                                                                                                                                              
                                                                                                                                                                                                                                   
  I want to submit **BPM (Browser Performance Metrics)** for inclusion in the repository.                                                                                                                                            
                                                                                                                                                                                                                                   
  **Why this plugin exists:**

 JMeter tells you how fast the server responded — but not what the browser experienced. Layout shifts, slow renders, heavy payloads, console errors — all invisible to every existing JMeter listener.

  Of all plugins in the catalogue, the closest is jpgc-webdriver — but it only runs Selenium scripts and records the elapsed time. No plugin captures browser rendering metrics. **BPM is the first JMeter plugin to capture Core Web Vitals during load test execution.**

  **What it captures — live, per transaction, via Chrome DevTools Protocol:**

  - Core Web Vitals: LCP, FCP, CLS, TTFB
  - Composite performance score with SLA threshold highlighting
  - Network requests, runtime errors, console errors
  - Primary improvement area per transaction (frontend / backend / stability)
  - Retroactive filtering by time offset, transaction name, regex
  - Standalone HTML report with trend charts, SLA compliance, and Excel export — generated entirely in Java, no AI or external API calls required. Available from GUI or CLI.

  **Details:**

  - Maven Central: io.github.sagaraggarwal86:bpm-jmeter-plugin:1.0.0
  - License: Apache 2.0
  - JMeter 5.6.3 / Java 17

  Happy to answer questions or make adjustments.