### PR TITLE
Add jmeter-grpc-request v2.0.0 - CVE fixes and mTLS support

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1763,6 +1763,13 @@
         "depends": [
           "jmeter-core"
         ]
+      },
+      "2.0.0": {
+        "changes": "Security: CVE fixes (commons-io 2.14.0 for CVE-2024-47554, TestNG 7.5.1 for CVE-2022-4065). Added Mutual TLS (mTLS) support with client certificate, client key, and CA certificate fields. JDK 8 compatible (bytecode 52).",
+        "downloadUrl": "https://github.com/bakthava/jmeter-grpc-request/releases/download/v2.0.0/jmeter-grpc-request.2.0.0.jar",
+        "depends": [
+          "jmeter-core"
+        ]
       }
     }
   },

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1716,8 +1716,8 @@
     "name": "JMeter gRPC Request",
     "description": "Send gRPC request",
     "screenshotUrl": "https://user-images.githubusercontent.com/15891411/93206727-121f3400-f784-11ea-890f-0ba6c6aaee9e.png",
-    "helpUrl": "https://github.com/zalopay-oss/jmeter-grpc-request",
-    "vendor": "Datadog",
+    "helpUrl": "https://github.com/bakthava/jmeter-grpc-request",
+    "vendor": "bakthava",
     "markerClass": "vn.zalopay.benchmark.GRPCSamplerGui",
     "componentClasses": [
       "vn.zalopay.benchmarkGRPCSampler"
@@ -1765,7 +1765,7 @@
         ]
       },
       "2.0.0": {
-        "changes": "Security: CVE fixes (commons-io 2.14.0 for CVE-2024-47554, TestNG 7.5.1 for CVE-2022-4065). Added Mutual TLS (mTLS) support with client certificate, client key, and CA certificate fields. JDK 8 compatible (bytecode 52).",
+        "changes": "Continuation of the archived zalopay-oss/jmeter-grpc-request project. Security: fixed 18 CVEs — xstream 1.4.21 (CVE-2022-41966, CVE-2022-40151, CVE-2024-47072), jackson-databind 2.17.2 (CVE-2022-42004, CVE-2022-42003), excluded EOL log4j 1.x (CVE-2019-17571 CRITICAL), json-smart 2.5.2 (CVE-2023-1370, CVE-2024-57699), batik 1.17 (CVE-2022-44729), bouncycastle 1.70 (14+ CVEs), Netty 4.1.132.Final, gRPC 1.68.1, protobuf 3.25.5. New feature: Mutual TLS (mTLS) support. JDK 8 compatible (bytecode 52).",
         "downloadUrl": "https://github.com/bakthava/jmeter-grpc-request/releases/download/v2.0.0/jmeter-grpc-request.2.0.0.jar",
         "depends": [
           "jmeter-core"


### PR DESCRIPTION
## JMeter gRPC Request Plugin - Version 2.0.0

### Plugin Details

- **Plugin ID**: jmeter-grpc-request
- **Latest Version**: 2.0.0
- **GitHub Repository**: https://github.com/bakthava/jmeter-grpc-request

### What's New in v2.0.0

#### Security Fixes (CVE)
- **CVE-2024-47554** (HIGH): Upgraded \commons-io\ from 2.11.0 to 2.14.0 — fixes uncontrolled resource consumption in \XmlStreamReader\
- **CVE-2022-4065** (HIGH): Upgraded \TestNG\ from 7.6.1 to 7.5.1 — fixes path traversal in \JarFileUtils\

#### New Feature: Mutual TLS (mTLS) Support
Added client certificate authentication for servers requiring mTLS:
- **Client Certificate File** field (Browse button in GUI)
- **Client Key File** field (Browse button in GUI)
- **CA Certificate File** field — optional custom CA for server verification
- New sampler properties: \GRPCSampler.clientCertFile\, \GRPCSampler.clientKeyFile\, \GRPCSampler.caCertFile\

#### Compatibility
- JDK 8 compatible (bytecode version 52)
- Compiled and tested with OpenJDK 8 (Temurin 1.8.0_482)

### Technical Details

- **Release JAR v2.0.0**: https://github.com/bakthava/jmeter-grpc-request/releases/download/v2.0.0/jmeter-grpc-request.2.0.0.jar
