### PR TITLE
Initial release — auto-snapshot on save, manual checkpoint, version h…

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -27,6 +27,26 @@
     }
   },
   {
+    "id": "io.github.sagaraggarwal86-jmx-version-control-system",
+    "name": "JVCS — JMX Version Control System",
+    "description": "A lightweight local version control plugin for Apache JMeter test plans (.jmx files). Auto-snapshots on every save with SHA-256 deduplication, manual checkpoints with notes, one-click rollback with safety net, version freezing, configurable retention with FIFO pruning, periodic auto-checkpoint, selective deletion, export to .jmx, audit trail, lock file mechanism, dirty state indicator, self-healing index, toolbar integration, keyboard shortcuts (Ctrl+K, Ctrl+H) — no Git, no SVN, no external tools required.",
+    "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/jmx-version-control-system/main/docs/Image.jpeg",
+    "helpUrl": "https://github.com/sagaraggarwal86/jmx-version-control-system/blob/main/README.md",
+    "vendor": "Sagar Aggarwal",
+    "markerClass": "io.github.sagaraggarwal86.jmeter.scm.ui.ScmMenuCreator",
+    "componentClasses": [
+      "io.github.sagaraggarwal86.jmeter.scm.ui.ScmMenuCreator",
+      "io.github.sagaraggarwal86.jmeter.scm.core.SaveCommandWrapper",
+      "io.github.sagaraggarwal86.jmeter.scm.core.ScmOpenListener"
+    ],
+    "versions": {
+      "1.1.0": {
+        "changes": "Initial release — auto-snapshot on save, manual checkpoint, version history panel, one-click restore, freeze/unfreeze, retention pruning, auto-checkpoint, selective deletion, export, audit log, lock management, dirty indicator, toolbar buttons, settings dialog, self-healing index, storage migration",
+        "downloadUrl": "https://repo1.maven.org/maven2/io/github/sagaraggarwal86/jmx-version-control-system/v1.1.0/jmx-version-control-system-v1.1.0.jar"
+      }
+    }
+  },
+  {
     "id": "io.github.sagaraggarwal86-bpm-jmeter-plugin",
     "name": "BPM — Browser Performance Metrics",
     "description": "A live JMeter listener plugin for capturing browser rendering metrics via Chrome DevTools Protocol. Features include Core Web Vitals (LCP, FCP, CLS, TTFB), Network & Console capture, Composite Performance Score, SLA Threshold Highlighting, Improvement Area Detection, Filter by Start/End Offset & Transaction Names with RegEx support, CLI Headless Mode, Chart Interval Control, HTML Performance Report, and Excel Export — with minimal impact on JMeter thread performance.",


### PR DESCRIPTION
Hi,

I'd like to submit a new plugin — **JVCS (JMX Version Control System)** — for inclusion in the repository.

I built this because I kept losing work in JMeter. You tweak a test plan, save over it, realise the previous version was better — and it's gone. Undo doesn't survive across sessions, and most QA teams I've worked with don't put .jmx files in Git. JVCS adds local version control directly inside JMeter, so you never lose a previous state again.

**What it does:**
1. Automatically snapshots your test plan on every save — duplicates are detected and skipped
2. Manual checkpoints with optional notes and the ability to freeze important versions so they're never pruned
3. One-click restore to any previous version — current state is always auto-saved first, so rollback can't lose work
4. Configurable retention (default 20 versions per plan) with automatic pruning of the oldest versions
5. Periodic auto-checkpoint for time-based snapshots (disabled by default)
6. Export any snapshot as a standalone .jmx, selective bulk deletion, and a full audit trail of every action
7. Self-healing — if the index gets corrupted, it rebuilds from the snapshot files on disk

**Why it's useful:**
1. JMeter has no persistent undo. Close the file, and your history is gone. JVCS fixes that with zero workflow change — just keep saving as normal.
2. Purely additive — never touches JMeter's own behavior. If anything in the plugin fails, JMeter keeps working exactly as before.
3. Zero configuration. Drop the JAR in lib/ext/, restart, and it's active on first save.

Plugin is on Maven Central (io.github.sagaraggarwal86:jmx-version-control-system:v1.1.0), Apache 2.0 licensed, and targets JMeter 5.6.3 / Java 17.

Happy to answer any questions or make adjustments to the entry.
![Image](https://github.com/user-attachments/assets/c2b3aa5c-5ee5-497f-8851-f1eaae2e70dd)
