### PR TITLE
Add jmeter-grpc-request v2.0.2

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -1797,6 +1797,13 @@
         "depends": [
           "jmeter-core"
         ]
+      },
+      "2.0.2": {
+        "changes": "Dependency updates: lombok 1.18.44, gson 2.13.2, fastjson 2.0.61, mockito-core 5.23.0, jacoco-maven-plugin 0.8.14, jmeter-plugins-emulators 0.5",
+        "downloadUrl": "https://github.com/bakthava/jmeter-grpc-request/releases/download/v2.0.2/jmeter-grpc-request.2.0.2.jar",
+        "depends": [
+          "jmeter-core"
+        ]
       }
     }
   },


### PR DESCRIPTION
## jmeter-grpc-request v2.0.2

This PR adds version 2.0.2 of the [JMeter gRPC Request](https://github.com/bakthava/jmeter-grpc-request) plugin to the registry.

### Changes in v2.0.2
- Dependency updates:
  - lombok 1.18.44
  - gson 2.13.2
  - fastjson 2.0.61
  - mockito-core 5.23.0
  - jacoco-maven-plugin 0.8.14
  - jmeter-plugins-emulators 0.5

### Download
- JAR: https://github.com/bakthava/jmeter-grpc-request/releases/download/v2.0.2/jmeter-grpc-request.2.0.2.jar
- Release: https://github.com/bakthava/jmeter-grpc-request/releases/tag/v2.0.2