### PR TITLE
Blazemeter/HLSPlugin release v3.3.0

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -661,6 +661,26 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.3.0": {
+        "changes": "HLS live-edge playback; DASH dynamic MPD refresh & timeline precision",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jmeter-bzm-hls-3.3.0.jar",
+        "libs": {
+          "hlsparserj>=1.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/hlsparserj-1.0.1.jar",
+          "jackson-annotations>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jackson-annotations-2.11.0.jar",
+          "jackson-core>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jackson-core-2.10.0.jar",
+          "jackson-databind>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jackson-databind-2.11.0.jar",
+          "jackson-dataformat-xml>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jackson-dataformat-xml-2.10.0.jar",
+          "jackson-module-jaxb-annotations>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jackson-module-jaxb-annotations-2.10.0.jar",
+          "jaxb-api>=2.3.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jaxb-api-2.3.1.jar",
+          "jmeter-bzm-commons>=0.2.3": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/jmeter-bzm-commons-0.2.3.jar",
+          "mpd-tools>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/mpd-tools-release-0.8-jdk8.jar",
+          "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/stax2-api-4.2.jar",
+          "woodstox-core>=6.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.0/woodstox-core-6.0.1.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
### What's new

- **CI on GitHub Action**
  Build on every push, JMeter compatibility matrix (several JMeter versions + optional BlazeMeter cloud Taurus run), master/slave integration test, pinned Taurus/urwid to avoid upstream resolver breakages, JMeter and artifact caching
- **DASH**
  More correct dynamic manifest refresh (wait uses the sampler clock, refresh when the MPD is exhausted), and more precise segment timeline math (large startNumber / SegmentTimeline / presentationTimeOffset after refresh)
- **HLS**
  Optional “Start from live edge” for live/EVENT playlists (skips to near the live window; VOD unchanged; UI disabled for MPEG-DASH)
    > Read more about this feature in its [README](https://github.com/Blazemeter/HLSPlugin/tree/master#start-from-live-edge) section. 





#### What's Changed
* Setup pipelines by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/41
* Fix DASH manifest refresh cadence and segment timeline precision by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/42
* HLS live edge setting by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/43
* Document start from live edge by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/45
* Pre Release by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/44


**Full Changelog**: https://github.com/Blazemeter/HLSPlugin/compare/v3.2.1...v3.3.0