### PR TITLE
AddNewPlugin_JMXAuditor - Initial Release

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -27,6 +27,24 @@
     }
   },
   {
+    "id": "io.github.sagaraggarwal86-jmxauditor",
+    "name": "JMXAuditor — JMX Static Analyser",
+    "description": "A JMeter GUI-mode plugin that performs static analysis on .jmx test plans. Surfaces findings across six quality categories (Correctness, Security, Scalability, Realism, Maintainability, Observability) with 25 read-only rules. HTML & JSON Report Export, with zero impact on test execution.",
+    "screenshotUrl": "https://raw.githubusercontent.com/sagaraggarwal86/JMXAuditor-jmeter-plugin/main/docs/Image.jpg",
+    "helpUrl": "https://github.com/sagaraggarwal86/JMXAuditor-jmeter-plugin/blob/main/README.md",
+    "vendor": "Sagar Aggarwal",
+    "markerClass": "io.github.sagaraggarwal86.jmeter.jmxauditor.ui.action.JMXAuditorMenuCreator",
+    "componentClasses": [
+      "io.github.sagaraggarwal86.jmeter.jmxauditor.ui.action.JMXAuditorMenuCreator"
+    ],
+    "versions": {
+      "0.6.0": {
+        "changes": "Initial public release",
+        "downloadUrl": "https://repo1.maven.org/maven2/io/github/sagaraggarwal86/jmxauditor-jmeter-plugin/0.6.0/jmxauditor-jmeter-plugin-0.6.0.jar"
+      }
+    }
+  },
+  {
     "id": "io.github.sagaraggarwal86-jmx-version-control-system",
     "name": "JVCS — JMX Version Control System",
     "description": "A lightweight local version control plugin for Apache JMeter test plans (.jmx files). Auto-snapshots on every save with SHA-256 deduplication, manual checkpoints with notes, one-click rollback with safety net, version freezing, configurable retention with FIFO pruning, periodic auto-checkpoint, selective deletion, export to .jmx, audit trail, lock file mechanism, dirty state indicator, self-healing index, toolbar integration, keyboard shortcuts (Ctrl+K, Ctrl+H) — no Git, no SVN, no external tools required.",


### PR DESCRIPTION
Hi,
                                                                                                                                                                                                                           I'd like to submit a new plugin — JMXAuditor — for inclusion in the repository.
                                                                                                                                                                                                                           
I built this because the same classic mistakes keep slipping through to the load run. You leave a GUI listener on the load path, spin up the environment, generate the data, run for half an hour — and the throughput numbers are off. Or someone leaves a plaintext password in a request body and only spots it after it's already in the logs. 

Existing approaches answer "is this test plan valid?" — does it parse, does it execute. JMXAuditor answers a different question: "is it well-designed?" A plan can be perfectly valid and still leak credentials in the request body, drop throughput from a GUI listener on the load path, or send identical requests with no think time. Those issues only surface at run time, when the cost of fixing them is highest. JMXAuditor scans the open test plan and flags those issues in seconds.

**What it does:**
- Runs 25 rules across six categories — Correctness, Security, Scalability, Realism, Maintainability, Observability — over the currently-loaded test plan
- Shows results in a modeless dialog with severity tabs (All / High / Medium / Low) and per-category toggles, so you can focus on what matters
- Double-click any finding to jump straight to the offending element in JMeter's tree
- Right-click a finding to hide that rule for the rest of the session if it's noisy on this particular plan
- Export the report as HTML (a single self-contained file), JSON (schema v1.0), or Excel 
- Full keyboard control — Esc to close, F5 / Ctrl+R to rescan, Enter to navigate, 1–4 for severity, Alt+1–6 for category
- Zero configuration. Drop the JAR in lib/ext/, restart JMeter, and Tools → Audit Script (Ctrl+Shift+A) is there. Open any .jmx, hit the shortcut, and you have findings.

Plugin is on Maven Central (io.github.sagaraggarwal86:jmxauditor-jmeter-plugin:0.6.0), Apache 2.0 licensed, and targets JMeter 5.6.3 / Java 17.

Happy to answer any questions or make adjustments to the entry.
[[Sample_Report.html](https://github.com/user-attachments/files/27084775/Sample_Report.html)](https://github.com/sagaraggarwal86/JMXAuditor-jmeter-plugin/blob/main/docs/Sample_Report.html)

[<img width="1522" height="857" alt="Image" src="https://github.com/user-attachments/assets/40d79a11-f1c3-488d-8795-507c33502ae1" />](https://raw.githubusercontent.com/sagaraggarwal86/JMXAuditor-jmeter-plugin/main/docs/Image.jpg)