### PR TITLE
Add cURL Import/Export Plugin

### DIFF
--- a/site/dat/repo/curl-import-export.json
+++ b/site/dat/repo/curl-import-export.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "com.prince.jmeter.curl",
+    "name": "cURL Import/Export Plugin",
+    "description": "Import cURL commands as HTTP Request samplers and export JMeter HTTP Request samplers as cURL commands.",
+    "screenshotUrl": "https://raw.githubusercontent.com/prince205927/jmeter-curl-plugin/main/screenshots/import-dialog.png",    "helpUrl": "https://github.com/prince205927/jmeter-curl-plugin",
+    "vendor": "Prince Sapkota<sapkotaprince17@gmail.com>",
+    "markerClass": "com.prince.jmeter.curl.CurlPluginMenuCreator",
+    "installerClass": null,
+    "versions": {
+      "1.0.0": {
+        "downloadUrl": "https://github.com/prince205927/jmeter-curl-plugin/releases/download/v1.0.0/jmeter-curl-plugin-1.0.0.jar",
+        "libs": {},
+        "depends": [],
+        "minJmeterVersion": "5.5"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## New Plugin: cURL Import/Export

### What it does
This plugin adds two features to JMeter:
1. **Import from cURL** — Paste any cURL command (from Chrome DevTools, 
   Firefox, Postman, documentation) and generate a fully configured 
   HTTP Request sampler with headers, body, auth, cookies, and timeouts
2. **Export as cURL** — Select any HTTP Request sampler and copy it 
   as a ready-to-use cURL command

### Why it's useful
- Developers share API calls as cURL commands daily 
- Browser DevTools provide "Copy as cURL" but getting that into JMeter 
  is currently a painful manual process
- No existing JMeter plugin provides this functionality

### Plugin Details
- **GitHub repo:** https://github.com/prince205927/jmeter-curl-plugin
- **License:** Apache 2.0
- **Minimum JMeter version:** 5.5
- **Java version:** 11+
- **No external dependencies** — only uses JMeter provided libraries

### Screenshots
![Import Dialog](https://raw.githubusercontent.com/prince205927/jmeter-curl-plugin/main/screenshots/import-dialog.png)
![Export Dialog](https://raw.githubusercontent.com/prince205927/jmeter-curl-plugin/main/screenshots/export-dialog.png)