### PR TITLE
Update jtl-xls-smart-report to v3.0.0

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3190,7 +3190,11 @@
       "2.0.0": {
         "changes": "Added headless CLI mode for CI/CD pipelines and GitHub Actions. Added P95 metric column. Auto-creates output directory if missing. Empty prefix now includes all transactions.",
         "downloadUrl": "https://github.com/rishavsawarn/jmeter-jtl-xls-report-plugin/releases/download/v2.0.0/jmeter-jtl-xls-report-plugin-2.0.0-jar-with-dependencies.jar"
-      }
+      },
+      "3.0.0": {
+        "changes": "Baseline JTL comparison support. The Excel report now contains three sheets: Current, Baseline, and Comparison. Added 'Baseline Directory' field in the GUI listener.",
+        "downloadUrl": "https://github.com/rishavsawarn/jmeter-jtl-xls-report-plugin/releases/download/v3.0.0/jmeter-jtl-xls-report-plugin-v3.0.0.jar"
+     }
     }
   },
   {

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3194,7 +3194,7 @@
       "3.0.0": {
         "changes": "Baseline JTL comparison support. The Excel report now contains three sheets: Current, Baseline, and Comparison. Added 'Baseline Directory' field in the GUI listener.",
         "downloadUrl": "https://github.com/rishavsawarn/jmeter-jtl-xls-report-plugin/releases/download/v3.0.0/jmeter-jtl-xls-report-plugin-v3.0.0.jar"
-     }
+      }
     }
   },
   {


### PR DESCRIPTION
Adds v3.0.0 release of the JTL Excel Smart Report Generator plugin.

The plugin now produces a 3-sheet Excel workbook (Current, Baseline, Comparison) when a baseline JTL directory is supplied via the new "Baseline Directory" field in the GUI listener. Existing API and CLI flags are unchanged — backward compatible with v2.0.0.

Download URL:
https://github.com/rishavsawarn/jmeter-jtl-xls-report-plugin/releases/download/v3.0.0/jmeter-jtl-xls-report-plugin-v3.0.0.jar