### PR TITLE
Blazemeter/jmeter-http2-plugin release v3.0.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1022,6 +1022,14 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.0.1": {
+        "changes": "BlazeMeter HTTP",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v3.0.1/jmeter-bzm-http2-3.0.1.jar",
+        "libs": {},
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },

--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -722,8 +722,8 @@
   },
   {
     "id": "bzm-http2",
-    "name": "BlazeMeter - HTTP/2 Plugin",
-    "description": "HTTP/2 protocol sampler",
+    "name": "BlazeMeter - HTTP Plugin",
+    "description": "BlazeMeter HTTP (HTTP/1.1, HTTP/2, HTTP/3)",
     "helpUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/blob/master/README.md",
     "screenshotUrl": "https://raw.githubusercontent.com/Blazemeter/jmeter-http2-plugin/master/docs/addHTTP2Sampler.png",
     "vendor": "BlazeMeter",
@@ -1024,9 +1024,8 @@
         ]
       },
       "3.0.1": {
-        "changes": "BlazeMeter HTTP",
+        "changes": "Plugin renamed to BlazeMeter HTTP. Protocol support: HTTP/1.x, HTTP/2 and HTTP/3. Recording support and many other improvements.",
         "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v3.0.1/jmeter-bzm-http2-3.0.1.jar",
-        "libs": {},
         "depends": [
           "jmeter-http"
         ]


### PR DESCRIPTION
# BlazeMeter HTTP v3.0.1

**Major release** with plugin rename, Jetty 12 upgrade and full modern protocol support.

### Highlights

- **Plugin renamed** to **BlazeMeter HTTP**
- Upgraded to **Jetty 12.1.6** with official support for **HTTP/3 + QUIC**
- Full protocol support: **HTTP/1.x**, **HTTP/2** and **HTTP/3**
- Added advanced compression: **Brotli**, **Zstandard** and **Gzip**
- Improved compatibility with JMeter Recorder and **BlazeMeter Automatic Correlation Recorder**

### Key Improvements

- **Better scenario modeling**: Much more realistic and complex test scenarios are now possible
- **Recorder support**: Fully compatible with JMeter’s HTTP(S) Test Script Recorder and BlazeMeter’s Automatic Correlation Recorder
- Modernized build system with dependency shading (SLF4J + Jetty) for better isolation
- Updated to Java 17 compilation while keeping Java 8 runtime compatibility for user messages related with Java 17+ requirement.

### What's Changed (v3.0.1)

* Brotli cross-platform support has been fixed. Issue: https://github.com/Blazemeter/jmeter-http2-plugin/issues/99 reported by @Pill30 
* Duplicate Request Body in HTTP Async Controller fixed when "Generate Parent Sample" is enabled. Issue: https://github.com/Blazemeter/jmeter-http2-plugin/issues/100 reported by @Pill30 
* Bootsrap Menu Creator for Java 8+ support (Java 17+ compatibility message for earlier Java versions) by @3dgiordano in PR: https://github.com/Blazemeter/jmeter-http2-plugin/pull/98

Thanks to the users @Pill30 and @heysarthak for all the feedback provided on this latest major release.

---

**Recommended for all users.** This is a major upgrade that significantly expands protocol support and recording capabilities.

Enjoy the new version! 🚀

**Full Changelog**: https://github.com/Blazemeter/jmeter-http2-plugin/compare/v3.0.0...v3.0.1