### PR TITLE
Add HAR vs JMeter Listener plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3468,5 +3468,19 @@
         }
       }
     }
+  },
+  {
+  "id": "har-jmeter-listener",
+  "name": "HAR vs JMeter Listener",
+  "description": "Compares real browser load time (HAR files) with JMeter sampler results side by side. Matches requests by URL, generates an HTML report with diffs, waterfall view, and a built-in Why-the-diff reference guide. Works in Live mode and Offline mode.",
+  "helpUrl": "https://github.com/Vishhh-alt/HAR_vs_Jmeter",
+  "vendor": "Visvashwarr Venugopal",
+  "versions": {
+    "1.0.0": {
+      "downloadUrl": "https://github.com/Vishhh-alt/HAR_vs_Jmeter/releases/download/v1.0.0/har-jmeter-listener-1.0.0-plugin.jar",
+      "libs": {},
+      "depends": []
+    }
   }
+}
 ]


### PR DESCRIPTION
New plugin submission: HAR vs JMeter Listener

Compares real browser load time (HAR files) with JMeter sampler 
results side by side. Native JMeter Listener, installs via lib/ext.

GitHub: https://github.com/Vishhh-alt/HAR_vs_Jmeter
JAR: https://github.com/Vishhh-alt/HAR_vs_Jmeter/releases
Author: Visvashwarr Venugopal
Requires: JMeter 5.x, Java 11+, Python 3.7+