### PR TITLE
Add JMeter HTML Report Plugin

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3476,11 +3476,11 @@
     "screenshotUrl": "",
     "helpUrl": "https://github.com/srenevasanks/jmeter-html-report-plugin",
     "vendor": "Srenevasan",
-	"markerClass": "listener.CustomHtmlReportListener",
-	"componentClasses": [
-	    "listener.CustomHtmlReportListener",
-	    "gui.CustomHtmlReportGui"
-	],
+    "markerClass": "listener.CustomHtmlReportListener",
+    "componentClasses": [
+      "listener.CustomHtmlReportListener",
+      "gui.CustomHtmlReportGui"
+    ],
     "versions": {
       "1.0.0": {
         "changes": "Initial public release.",

--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3468,5 +3468,28 @@
         }
       }
     }
+  },
+  {
+    "id": "jmeter-html-report-plugin",
+    "name": "JMeter HTML Report Plugin",
+    "description": "Interactive HTML report generator for JMeter API testing with request/response details, assertion results, filtering, charts and dark mode support.",
+    "screenshotUrl": "",
+    "helpUrl": "https://github.com/srenevasanks/jmeter-html-report-plugin",
+    "vendor": "Srenevasan",
+	"markerClass": "listener.CustomHtmlReportListener",
+	"componentClasses": [
+	    "listener.CustomHtmlReportListener",
+	    "gui.CustomHtmlReportGui"
+	],
+    "versions": {
+      "1.0.0": {
+        "changes": "Initial public release.",
+        "downloadUrl": "https://github.com/srenevasanks/jmeter-html-report-plugin/releases/download/v1.0.0/jmeter-html-report-plugin-1.0.0.jar",
+        "depends": [
+          "jmeter-core"
+        ],
+        "libs": {}
+      }
+    }
   }
 ]


### PR DESCRIPTION
This PR adds a new plugin to the JMeter Plugins Manager catalog.

Plugin: JMeter HTML Report Plugin

Features:

* Interactive HTML report generation
* API-level pass/fail summary
* Request and response payload viewer
* Request and response headers
* Assertion results and failure details
* Search and filtering capabilities
* Execution statistics and charts
* Dark mode support

Repository:
https://github.com/srenevasanks/jmeter-html-report-plugin

Release:
https://github.com/srenevasanks/jmeter-html-report-plugin/releases/tag/v1.0.0

License:
Apache License 2.0

Version:
1.0.0