### PR TITLE
feat: add Mock Jutsu synthetic test data plugin (390 types, 6 locales)

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3600,5 +3600,22 @@
         "libs": {}
       }
     }
+  },
+  {
+    "id": "mock-jutsu",
+    "name": "Mock Jutsu - The Ultimate Algorithmic Mock Data Engine",
+    "description": "Generate format-valid synthetic test data directly inside JMeter test plans via custom functions - no Python, no subprocess, no CSV files needed. 390 types across 49 categories, 6 locales (TR/UK/US/DE/FR/RU), pipe-separated options, mask support (PCI DSS / GDPR / KVKK), zero external dependencies.",
+    "helpUrl": "https://github.com/altansayan/mock-jutsu-jmeter#readme",
+    "markerClass": "com.mockjutsu.jmeter.MockJutsuBaseFunction",
+    "screenshotUrl": "https://raw.githubusercontent.com/altansayan/mock-jutsu-jmeter/main/assets/function-helper-preview.png",
+    "vendor": "ASA Intelligence - Altan Sezer Ayan",
+    "versions": {
+      "1.0.0": {
+        "changes": "Initial release - 390 types, 49 categories, pipe separator syntax, mask support, 5955 tests passed.",
+        "downloadUrl": "https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.0.0/mock-jutsu-jmeter-1.0.0.jar",
+        "libs": {},
+        "depends": []
+      }
+    }
   }
 ]


### PR DESCRIPTION
  ## Plugin: Mock Jutsu

  Adds Mock Jutsu, an algorithmic mock data engine for JMeter.

  ### What it does
  Generates format-valid synthetic test data directly inside JMeter test plans
  via custom functions — no Python, no subprocess, no CSV files needed.

  ### Key features
  - 390 data types across 49 categories
  - 6 locales (TR · UK · US · DE · FR · RU)
  - Pipe-separated syntax: `${__mockjutsu_financial(cardnum:visa|TR|mask)}`
  - Mask support (PCI DSS / GDPR / KVKK)
  - Zero external dependencies
  - 5955 tests passed

  ### Links
  - GitHub: https://github.com/altansayan/mock-jutsu-jmeter
  - Release: https://github.com/altansayan/mock-jutsu-jmeter/releases/tag/v1.0.0
  - License: MIT