### PR TITLE
Blazemeter/HLSPlugin release v3.3.2

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -702,6 +702,27 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.3.2": {
+        "changes": "Performance enhancements",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jmeter-bzm-hls-3.3.2.jar",
+        "libs": {
+          "hlsparserj>=1.0.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/hlsparserj-1.0.2.jar",
+          "jackson-annotations>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jackson-annotations-2.11.0.jar",
+          "jackson-core>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jackson-core-2.10.0.jar",
+          "jackson-databind>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jackson-databind-2.11.0.jar",
+          "jackson-dataformat-xml>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jackson-dataformat-xml-2.10.0.jar",
+          "jackson-module-jaxb-annotations>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jackson-module-jaxb-annotations-2.10.0.jar",
+          "jakarta.activation-api>=1.2.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jakarta.activation-api-1.2.1.jar",
+          "jakarta.xml.bind-api>=2.3.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jakarta.xml.bind-api-2.3.2.jar",
+          "jmeter-bzm-commons>=0.2.3": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/jmeter-bzm-commons-0.2.3.jar",
+          "mpd-tools>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/mpd-tools-release-0.8-jdk8.jar",
+          "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/stax2-api-4.2.jar",
+          "woodstox-core>=6.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.3.2/woodstox-core-6.0.1.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
# Blazemeter/HLSPlugin release v3.3.2

## Performance improvements

- Added new JMeter properties to reduce memory usage during long or large-scale streaming tests by releasing response bodies after processing:
  - `hls.sampler.releaseSegmentResponseData` (enabled by default) clears HLS/DASH media and init segment payload data after listeners are notified, while preserving metrics such as bytes, latency, throughput, response codes, and headers.
  - `hls.sampler.releasePlaylistResponseData` (disabled by default) optionally clears HLS playlists and DASH manifest response bodies during playback sampling.
- Improved HLS playlist parsing to avoid unnecessary line-ending normalization when not needed.
- Improved DASH manifest parsing efficiency and thread safety by reusing a shared parser instance.
- Added test coverage for concurrent DASH manifest parsing and for response-data release behavior.