### PR TITLE
Blazemeter/HLSPlugin release v3.4.0

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -723,6 +723,27 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.4.0": {
+        "changes": "Videostreaming Parallel Controller - Heartbeats along the streaming!",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jmeter-bzm-hls-3.4.0.jar",
+        "libs": {
+          "hlsparserj>=1.0.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/hlsparserj-1.0.2.jar",
+          "jackson-annotations>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jackson-annotations-2.11.0.jar",
+          "jackson-core>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jackson-core-2.10.0.jar",
+          "jackson-databind>=2.11.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jackson-databind-2.11.0.jar",
+          "jackson-dataformat-xml>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jackson-dataformat-xml-2.10.0.jar",
+          "jackson-module-jaxb-annotations>=2.10.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jackson-module-jaxb-annotations-2.10.0.jar",
+          "jakarta.activation-api>=1.2.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jakarta.activation-api-1.2.1.jar",
+          "jakarta.xml.bind-api>=2.3.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jakarta.xml.bind-api-2.3.2.jar",
+          "jmeter-bzm-commons>=0.2.3": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/jmeter-bzm-commons-0.2.3.jar",
+          "mpd-tools>=release-0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/mpd-tools-release-0.8-jdk8.jar",
+          "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/stax2-api-4.2.jar",
+          "woodstox-core>=6.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.4.0/woodstox-core-6.0.1.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
## What's new

- **Streaming Parallel Controller** — run periodic heartbeat / analytics requests alongside HLS or MPEG-DASH playback.
  - Add via `Add -> Logic Controller -> bzm - Streaming Parallel Controller`.
  - Place a **bzm - Streaming Sampler** as a **direct child** (playback track); put heartbeat request(s) as the remaining children (plain HTTP Samplers or under a Transaction/Logic Controller).
  - Configure **Heartbeat interval** (seconds, supports `${vars}`) and optional **Run heartbeat immediately**.
  - Playback resumes across slices without re-downloading the master playlist / DASH manifest each interval.
> [!NOTE]  
> Read more in the [README](https://github.com/Blazemeter/HLSPlugin/tree/master#running-periodic-requests-during-playback-streaming-parallel-controller) section!

## What's Changed
* Heartbeat request support by @Baraujo25 in https://github.com/Blazemeter/HLSPlugin/pull/53


**Full Changelog**: https://github.com/Blazemeter/HLSPlugin/compare/v3.3.2...v3.4.0