### PR TITLE
fix: update Mock Jutsu to v1.0.1 (Python parity fixes)

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3610,6 +3610,12 @@
     "screenshotUrl": "https://raw.githubusercontent.com/altansayan/mock-jutsu-jmeter/main/assets/function-helper-preview.png",
     "vendor": "ASA Intelligence - Altan Sezer Ayan",
     "versions": {
+      "1.0.1": {
+        "changes": "Not backward compatible with 1.0.0 - corrects 273 mismatches against the Python (mockjutsu) reference implementation across all 39 generator files, fixes a Turkish-locale decimal separator bug, removes a dead registry entry. 4191 tests passed.",
+        "downloadUrl": "https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.0.1/mock-jutsu-jmeter-1.0.1.jar",
+        "libs": {},
+        "depends": []
+      },
       "1.0.0": {
         "changes": "Initial release - 390 types, 49 categories, pipe separator syntax, mask support, 5955 tests passed.",
         "downloadUrl": "https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.0.0/mock-jutsu-jmeter-1.0.0.jar",


### PR DESCRIPTION
## Plugin: Mock Jutsu — version bump to 1.0.1

Adds the 1.0.1 release entry to the existing Mock Jutsu listing.

### What changed
Not backward compatible with 1.0.0 — corrects 273 mismatches found against
the Python (mockjutsu) reference implementation across all 39 generator
files, fixes a Turkish-locale decimal separator bug (comma instead of
period in numeric fields), and removes a dead registry entry with no
backing implementation.

### Links
- GitHub: https://github.com/altansayan/mock-jutsu-jmeter
- Release: https://github.com/altansayan/mock-jutsu-jmeter/releases/tag/v1.0.1
- Changelog: https://github.com/altansayan/mock-jutsu-jmeter/blob/main/CHANGELOG.md
- License: MIT