### PR TITLE
fix: update Mock Jutsu to v1.1.1 (ThreadLocal concurrency fixes)

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3612,12 +3612,18 @@
   {
     "id": "mock-jutsu",
     "name": "Mock Jutsu - The Ultimate Algorithmic Mock Data Engine",
-    "description": "Generate format-valid synthetic test data directly inside JMeter test plans via custom functions - no Python, no subprocess, no CSV files needed. 390 types across 49 categories, 6 locales (TR/UK/US/DE/FR/RU), pipe-separated options, mask support (PCI DSS / GDPR / KVKK), zero external dependencies. Plugin Benchmark: https://github.com/altansayan/mock-jutsu-jmeter-plugin-benchmark",
+    "description": "Generate format & checksum-valid mock test data directly inside JMeter test plans via custom functions - no Python, no subprocess, no CSV files needed. 390 types across 49 categories, 6 locales (TR/UK/US/DE/FR/RU), pipe-separated options, mask support (PCI DSS / GDPR / KVKK), zero external dependencies.<br>Plugin Benchmark: https://github.com/altansayan/mock-jutsu-jmeter-plugin-benchmark",
     "helpUrl": "https://github.com/altansayan/mock-jutsu-jmeter#readme",
     "markerClass": "com.mockjutsu.jmeter.MockJutsuBaseFunction",
     "screenshotUrl": "https://raw.githubusercontent.com/altansayan/mock-jutsu-jmeter/main/assets/function-helper-preview.png",
     "vendor": "ASA Intelligence - Altan Sezer Ayan",
     "versions": {
+      "1.1.1": {
+        "changes": "Concurrency: ThreadLocal<SecureRandom>, ThreadLocal<Mac> (HmacSHA256), ThreadLocal<MessageDigest> (SHA-256/SHA-512) eliminate lock contention under concurrent load. DateTimeFormatter.ofPattern() hoisted to static final fields in 15 generators. CI: 426-sampler all-types JMeter smoke test on every PR.",
+        "downloadUrl": "https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.1.1/mock-jutsu-jmeter-1.1.1.jar",
+        "libs": {},
+        "depends": []
+      },
       "1.1.0": {
         "changes": "Performance: SecureRandom pool, JDK native EC crypto (crypto types 8-22ms to <1ms), Pattern cache, JWT SecureRandom consolidation. Bug fixes: 12 missing _masked registry entries, JSON control-char escapes, NUL byte in CryptoFuzzGen. Observability: SLF4J logging to all generators. Architecture: O(1) Map dispatch. Testing: per-type perf regression guard for all 429 type+qualifier combos. Benchmark: https://github.com/altansayan/mock-jutsu-jmeter-plugin-benchmark",
         "downloadUrl": "https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.1.0/mock-jutsu-jmeter-1.1.0.jar",


### PR DESCRIPTION
## Changes

Adds Mock Jutsu v1.1.1 to the registry and updates the plugin description.

### Version 1.1.1 — Concurrency fixes
- `ThreadLocal<SecureRandom>` — eliminates lock contention under concurrent load
- `ThreadLocal<Mac>` — per-thread HmacSHA256 in FinancialMarketsGen, MetaGen
- `ThreadLocal<MessageDigest>` — per-thread SHA-256/SHA-512 in CryptoFuzzGen, EcCrypto
- `DateTimeFormatter` hoisted to `static final` fields in 15 generator files
- CI: 426-sampler all-types JMeter smoke test runs on every PR

### Description update
- "format-valid synthetic" → "format & checksum-valid mock"
- Plugin Benchmark link moved to new line (`<br>`)

**Download:** https://github.com/altansayan/mock-jutsu-jmeter/releases/download/v1.1.1/mock-jutsu-jmeter-1.1.1.jar