### PR TITLE
Publish Plugins Manager 2.0 and switch the release command

### DIFF
--- a/maven-bundle.sh
+++ b/maven-bundle.sh
@@ -1,3 +1,5 @@
 #! /bin/sh -xe
 
-mvn -Dmaven.test.skip=true -Dadditionalparam=-Xdoclint:none -Dpackaging=jar clean package javadoc:jar source:jar verify gpg:sign deploy
+# mvn -Dmaven.test.skip=true -Dadditionalparam=-Xdoclint:none -Dpackaging=jar clean package javadoc:jar source:jar verify gpg:sign deploy
+mvn -Psonatype-oss-release clean deploy
+

--- a/site/dat/repo/self.json
+++ b/site/dat/repo/self.json
@@ -71,6 +71,13 @@
         "libs": {
           "cmdrunner>=2.3": "https://repo.maven.apache.org/maven2/kg/apc/cmdrunner/2.3/cmdrunner-2.3.jar"
         }
+      },
+      "2.0": {
+        "changes": "Much faster repository loading, half the download size. Requires JMeter 3.2+",
+        "downloadUrl": "https://repo.maven.apache.org/maven2/kg/apc/jmeter-plugins-manager/2.0/jmeter-plugins-manager-2.0.jar",
+        "libs": {
+          "cmdrunner>=2.3": "https://repo.maven.apache.org/maven2/kg/apc/cmdrunner/2.3/cmdrunner-2.3.jar"
+        }
       }
     }
   }


### PR DESCRIPTION
Two changes, both fallout from releasing jmeter-plugins-manager 2.0 to Central.

## `self.json` — the 2.0 entry

2.0 loads the repository several times faster and halves the download:

| | 1.12 | 2.0 |
|---|---|---|
| `load()` cold | 284 ms | 68 ms |
| `load()` warm | 86–154 ms | 15–29 ms |
| jar | 909,776 B | 460,245 B |

## Why the changes text says "Requires JMeter 3.2+"

The repo format has no way to express a version constraint — every user is offered the highest version regardless — so the `changes` string is the only channel that reaches the UI.

**3.2 is the real floor**, verified three ways against the shipped jar:

- all 21 referenced `org.apache.jmeter` / `org.apache.jorphan` classes exist in 3.2
- all 18 referenced methods resolve in 3.2
- `src/main` compiles clean against JMeter 3.2 with its log4j 2.8.2

The project now *builds* against 5.0, but nothing in the artifact requires it. Worth knowing that the two numbers disagree deliberately.

### Residual risk

Users below JMeter 3.2 — roughly the 0.3% band on the usage stats — will be offered an upgrade whose manager won't load, and `canUninstall` is `false`, so there's no UI path back. Small, but unpleasant for whoever hits it.

## `maven-bundle.sh`

```
- mvn -Dmaven.test.skip=true -Dadditionalparam=-Xdoclint:none -Dpackaging=jar clean package javadoc:jar source:jar verify gpg:sign deploy
+ mvn -Psonatype-oss-release clean deploy
```

The old form re-entered the lifecycle once per phase argument, so compile, jar and shade each ran two or three times over, and `gpg:sign` was invoked by hand instead of bound to `verify`. `-Dadditionalparam=-Xdoclint:none` was inert (a javadoc 2.x flag) and is now handled in the manager's POM; `-Dpackaging=jar` was redundant. This form also runs the tests, which the old one skipped.