### PR TITLE
Blazemeter/jmeter-http-plugin release v3.2.0

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1100,6 +1100,14 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.2.0": {
+        "changes": "Enhanced HTTP/2 (h2c) support, DNSCacheManager, BASIC_DIGEST authentication, source address binding, and improved connection/timing reliability.",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http-plugin/releases/download/v3.2.0/jmeter-bzm-http2-3.2.0.jar",
+        "libs": {},
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
# BlazeMeter HTTP v3.2.0

**Networking & protocol enhancements release** focused on stronger HTTP/2 (h2c) support, DNS integration, authentication improvements, and more robust connection/timing behavior.
### Highlights
- Full **DNSCacheManager** support for JMeter-aligned DNS handling
- **BASIC_DIGEST** authentication support
- Configurable **source address** for outgoing connections
- Improved **HTTP/2 cleartext (h2c)** support, including POST requests and fallback to HTTP/1.1
- Better visibility into the connection handshake process
- Timing fixes and collection of in-flight requests when a Thread Group duration ends
### Key Improvements
- **Protocol robustness**: Stronger h2c negotiation, ALPN handling (fallback to HTTP/1.1 when not specified), and POST support over HTTP/2 cleartext
- **JMeter parity**: DNSCacheManager integration, BASIC_DIGEST auth, and source-address binding for outgoing connections
- **Reliability**: Fixed subsample timeout doubling, sampler timing issues, and proper collection of in-flight requests at Thread Group end
- Enhanced connection handshake observability

### What's Changed (v3.2.0)
* Fixed an issue when reaching timeout in subsample setting double time… by @diego-ferrand in https://github.com/Blazemeter/jmeter-http-plugin/pull/154
* Add support for DNSCacheManager by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/158
* Add BASIC_DIGEST support by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/159
* Support source address for outgoing connections by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/160
* Enhance visibility of connection handshake process by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/161
* Use HTTP/1.1 when ALPN protocol is not specified by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/162
* Implement HTTP/2 support for h2c POST requests by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/164
* Fix timing issues in samplers by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/165
* Add H2C fallback to HTTP/1.1 support by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/166
* Collect in-flight requests on Thread Group duration end by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/167
* Release 3.2.0 by @3dgiordano in https://github.com/Blazemeter/jmeter-http-plugin/pull/163

Thanks to the users @Pill30 and @heysarthak for all the feedback provided.

These changes further improve protocol compatibility, connection control, and overall reliability while maintaining strong alignment with JMeter.

---
**Recommended for all users.** This release strengthens HTTP/2 handling, DNS support, and connection robustness.
Enjoy the new version! 🚀
**Full Changelog**: https://github.com/Blazemeter/jmeter-http-plugin/compare/v3.1.0...v3.2.0