### PR TITLE
Add Adaptive Capacity Listener plugin descriptor

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3721,5 +3721,26 @@
         "depends": []
       }
     }
+  },
+  {
+    "id": "adaptive-capacity-listener",
+    "name": "Adaptive Capacity Listener",
+    "description": "Multi-policy capacity degradation listener that monitors performance windows (latency growth %, absolute latency ceiling, error rate %, error count) and automatically halts tests upon threshold breaches with synthetic failure reporting.",
+    "screenshotUrl": "https://raw.githubusercontent.com/hilalsidhic/AdaptiveCapacityJmeterPlugin/master/assets/img.png",
+    "helpUrl": "https://github.com/hilalsidhic/AdaptiveCapacityJmeterPlugin",
+    "vendor": "Hilal Sidhic",
+    "markerClass": "io.github.hilalsidhic.jmeter.AdaptiveCapacityBackendListener",
+    "componentClasses": [
+      "io.github.hilalsidhic.jmeter.AdaptiveCapacityBackendListener",
+      "io.github.hilalsidhic.jmeter.AdaptiveCapacityListenerGui",
+      "io.github.hilalsidhic.jmeter.AdaptiveCapacityListenerTestElement",
+      "io.github.hilalsidhic.jmeter.AdaptiveCapacityMenuCreator"
+    ],
+    "versions": {
+      "1.0.1": {
+        "changes": "Initial release — multi-policy capacity degradation monitoring, automatic test halt on SLA breach, and failure reporting",
+        "downloadUrl": "https://github.com/hilalsidhic/AdaptiveCapacityJmeterPlugin/releases/download/v1.0.1/AdaptiveCapacityJmeterPlugin-1.0.1.jar"
+      }
+    }
   }
 ]


### PR DESCRIPTION
### Description

Adds the descriptor for **Adaptive Capacity Listener** (`adaptive-capacity-listener`) to `site/dat/repo/various.json`.

**Adaptive Capacity Listener** is an Apache JMeter listener and backend monitor plugin designed for adaptive capacity and resilience testing. It continuously tracks response performance over configurable evaluation windows and automatically halts tests when configured degradation or SLA thresholds are breached, injecting a synthetic failure sample to clearly mark threshold breaches in summary reports and HTML dashboards.

### Features
- **Multi-Policy Degradation Evaluation**:
  - `PERCENT_LATENCY`: Detects abnormal percentile latency growth compared to prior evaluation stages.
  - `ABSOLUTE_LATENCY`: Enforces a hard latency ceiling in milliseconds.
  - `ERROR_RATE`: Monitors error percentage per evaluation window.
  - `ERROR_COUNT`: Enforces a maximum acceptable error count per window.
- **Headless & CLI Compatible**: Operates both in JMeter GUI mode (under **Add → Listener**) and in headless/CLI mode via Backend Listener (`AdaptiveCapacityBackendListener`).

### Links
- **Repository & Docs**: https://github.com/hilalsidhic/AdaptiveCapacityJmeterPlugin
- **Release (v1.0.1)**: https://github.com/hilalsidhic/AdaptiveCapacityJmeterPlugin/releases/tag/v1.0.1
- **Download URL**: https://github.com/hilalsidhic/AdaptiveCapacityJmeterPlugin/releases/download/v1.0.1/AdaptiveCapacityJmeterPlugin-1.0.1.jar