### PR TITLE
Bump Feather Wand 3.8.2

### DIFF
--- a/site/dat/repo/various.json
+++ b/site/dat/repo/various.json
@@ -3265,6 +3265,14 @@
           "jmeter-core",
           "jmeter-components"
         ]
+      },
+      "3.8.2": {
+        "changes": "NEW: LLM Gateway support; Corporate gateway should work now; also use OpenRounter, LiteLLM, etc.",
+        "downloadUrl": "https://github.com/QAInsights/jmeter-ai/releases/download/v3.8.2/jmeter-agent-3.8.2.jar",
+        "depends": [
+          "jmeter-core",
+          "jmeter-components"
+        ]
       }
     }
   },


### PR DESCRIPTION
**What's new**

- Explicit Chat / Agent mode selector. The composer now defaults to safe Chat mode and only permits agentic JMeter tool calls after the user explicitly selects Agent mode.
- OpenAI and Anthropic gateway support. Route requests through custom OpenAI-compatible or Anthropic-compatible base URLs, provide gateway-specific headers, and configure model lists for gateways without model-discovery endpoints.

**Improvements and fixes**

- Added support for header-only gateway authentication while preserving API-key authentication.
- Added plaintext HTTP warnings for gateway URLs that could expose prompts or credentials.
- Improved gateway model discovery and filtering for non-OpenAI model IDs.
- Refreshed the vendored model-capability catalog and its Linux-based update workflow.
- Updated provider setup guidance and screenshots.