### PR TITLE
Fix AutoStop doc and test comment wording

### DIFF
--- a/plugins/autostop/src/test/java/kg/apc/jmeter/reporters/AutoStopTest.java
+++ b/plugins/autostop/src/test/java/kg/apc/jmeter/reporters/AutoStopTest.java
@@ -290,7 +290,7 @@ public class AutoStopTest {
         System.out.println("relativeWindowDisabledWhenNotConfigured");
         System.clearProperty("auto_stopped");
         AutoStop instance = new AutoStop();
-        // Rank blank, window and threshold set (Andrei's reproduction case)
+        // Rank blank, window and threshold set: must not fall back to comparing P0
         instance.setRelWindowSecs("1");
         instance.setRelThresholdPct("10");
         instance.testStarted();

--- a/site/dat/wiki/AutoStop.md
+++ b/site/dat/wiki/AutoStop.md
@@ -29,7 +29,7 @@ To disable auto-stop on rate criteria, just set error rate to zero.
 
 ## AutoStop on Percentile Response Time
 
-Percentile rank and threshold specified in milliseconds.
+Percentile rank specified as a number, e.g. 90 for P90; the threshold is specified in milliseconds.
 Test will be stopped only if specified percentile response time exceeded for *sequentially* N seconds.
 
 ## AutoStop on Relative Window Percentile Degradation


### PR DESCRIPTION
Follow-up to #883, cosmetics only — no behaviour change.

- `AutoStopTest`: reword a test comment that referenced the reviewer by name.
- `site/dat/wiki/AutoStop.md`: the Percentile Response Time section said the rank is specified in milliseconds; only the threshold is.

Still outstanding from the #883 review, not touched here:
- `JAutoStopPanelTest.java` is missing its trailing newline, and its new assertions use fully-qualified `org.junit.Assert.assertEquals` although the file already static-imports it.
- `jTextFieldCustomDuration` is still constructed and registered for validation but never displayed or read, and `AutoStop` retains the `custom_validation_duration` property plus `getCustomValidationDurationAsInt()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)